### PR TITLE
Added support for conversion to arma::Cube types 

### DIFF
--- a/inst/unitTests/cpp/cube.cpp
+++ b/inst/unitTests/cpp/cube.cpp
@@ -53,3 +53,39 @@ arma::cx_cube cx_cube_test(const arma::cx_cube& x) {
 arma::cx_fcube cx_fcube_test(const arma::cx_fcube& x) {
   return arma::pow(x, 2);
 }
+
+// [[Rcpp::export]]
+arma::cube as_cube(Rcpp::NumericVector x) {
+  arma::cube y = Rcpp::as<arma::cube>(x);
+  return arma::pow(y, 2);
+}
+
+// [[Rcpp::export]]
+arma::fcube as_fcube(Rcpp::NumericVector x) {
+  arma::fcube y = Rcpp::as<arma::fcube>(x);
+  return arma::pow(y, 2);
+}
+
+// [[Rcpp::export]]
+arma::icube as_icube(Rcpp::IntegerVector x) {
+  arma::icube y = Rcpp::as<arma::icube>(x);
+  return arma::pow(y, 2);
+}
+
+// [[Rcpp::export]]
+arma::ucube as_ucube(Rcpp::IntegerVector x) {
+  arma::ucube y = Rcpp::as<arma::ucube>(x);
+  return arma::pow(y, 2);
+}
+
+// [[Rcpp::export]]
+arma::cx_cube as_cx_cube(Rcpp::ComplexVector x) {
+  arma::cx_cube y = Rcpp::as<arma::cx_cube>(x);
+  return arma::pow(y, 2);
+}
+
+// [[Rcpp::export]]
+arma::cx_fcube as_cx_fcube(Rcpp::ComplexVector x) {
+  arma::cx_fcube y = Rcpp::as<arma::cx_fcube>(x);
+  return arma::pow(y, 2);
+}

--- a/inst/unitTests/cpp/cube.cpp
+++ b/inst/unitTests/cpp/cube.cpp
@@ -1,0 +1,55 @@
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
+//
+// cube.cpp: RcppArmadillo unit test code for cube types 
+//
+// Copyright (C) 2015 Dirk Eddelbuettel and Nathan Russell
+//
+// This file is part of RcppArmadillo.
+//
+// RcppArmadillo is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// RcppArmadillo is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with RcppArmadillo.  If not, see <http://www.gnu.org/licenses/>.
+
+// 30 November 2015
+
+// [[Rcpp::depends(RcppArmadillo)]]
+#include <RcppArmadillo.h>
+
+// [[Rcpp::export]]
+arma::cube cube_test(const arma::cube& x) {
+  return arma::pow(x, 2);
+}
+
+// [[Rcpp::export]]
+arma::fcube fcube_test(const arma::fcube& x) {
+  return arma::pow(x, 2);
+}
+
+// [[Rcpp::export]]
+arma::icube icube_test(const arma::icube& x) {
+  return arma::pow(x, 2);
+}
+
+// [[Rcpp::export]]
+arma::ucube ucube_test(const arma::ucube& x) {
+  return arma::pow(x, 2);
+}
+
+// [[Rcpp::export]]
+arma::cx_cube cx_cube_test(const arma::cx_cube& x) {
+  return arma::pow(x, 2);
+}
+
+// [[Rcpp::export]]
+arma::cx_fcube cx_fcube_test(const arma::cx_fcube& x) {
+  return arma::pow(x, 2);
+}

--- a/inst/unitTests/runit.cube.R
+++ b/inst/unitTests/runit.cube.R
@@ -28,17 +28,17 @@ test.cube <- function() {
   int_cube <- array(1L:27L, rep(3, 3))
   cplx_cube <- array(1.5:27.5 + 2i, rep(3, 3))
   
-  ## check cube (Cube<double>) and fcube (Cube<float>), no NAs
-  checkEquals(cube_test(dbl_cube), (dbl_cube ** 2), "cube_test no NA")
-  checkEquals(fcube_test(dbl_cube), (dbl_cube ** 2), "fcube_test no NA")
+  ## check cube (Cube<double>) and fcube (Cube<float>)
+  checkEquals(cube_test(dbl_cube), (dbl_cube ** 2), "cube_test")
+  checkEquals(fcube_test(dbl_cube), (dbl_cube ** 2), "fcube_test")
   
-  ## check icube (Cube<sword>) and ucube (Cube<uword>), no NAs
-  checkEquals(icube_test(int_cube), (int_cube ** 2), "icube_test no NA")
-  checkEquals(ucube_test(int_cube), (int_cube ** 2), "ucube_test no NA")
+  ## check icube (Cube<sword>) and ucube (Cube<uword>)
+  checkEquals(icube_test(int_cube), (int_cube ** 2), "icube_test")
+  checkEquals(ucube_test(int_cube), (int_cube ** 2), "ucube_test")
   
-  ## check cx_cube (Cube<cx_double>) and cx_fcube (Cube<cx_float>), no NAs
-  checkEquals(cx_cube_test(cplx_cube), (cplx_cube ** 2), "cx_cube_test no NA")
-  checkEquals(cx_fcube_test(cplx_cube), (cplx_cube ** 2), "cx_fcube_test no NA",
+  ## check cx_cube (Cube<cx_double>) and cx_fcube (Cube<cx_float>)
+  checkEquals(cx_cube_test(cplx_cube), (cplx_cube ** 2), "cx_cube_test")
+  checkEquals(cx_fcube_test(cplx_cube), (cplx_cube ** 2), "cx_fcube_test",
               tolerance = 1.5e-7)
   
   
@@ -70,4 +70,23 @@ test.cube <- function() {
   checkTrue(
     inherits(try(cx_fcube_test(cplx_cube), silent = TRUE), "try-error"),
     "cx_fcube_test bad dimensions")
+  
+  
+  ## sanity check for explicit calls to Rcpp::as< arma::Cube<T> > 
+  dbl_cube <- array(1.5:27.5, rep(3, 3))
+  int_cube <- array(1L:27L, rep(3, 3))
+  cplx_cube <- array(1.5:27.5 + 2i, rep(3, 3))
+  
+  ## check cube (Cube<double>) and fcube (Cube<float>)
+  checkEquals(as_cube(dbl_cube), (dbl_cube ** 2), "as_cube")
+  checkEquals(as_fcube(dbl_cube), (dbl_cube ** 2), "as_fcube")
+  
+  ## check icube (Cube<sword>) and ucube (Cube<uword>)
+  checkEquals(as_icube(int_cube), (int_cube ** 2), "as_icube")
+  checkEquals(as_ucube(int_cube), (int_cube ** 2), "as_ucube")
+  
+  ## check cx_cube (Cube<cx_double>) and cx_fcube (Cube<cx_float>)
+  checkEquals(as_cx_cube(cplx_cube), (cplx_cube ** 2), "as_cx_cube")
+  checkEquals(as_cx_fcube(cplx_cube), (cplx_cube ** 2), "as_cx_fcube",
+              tolerance = 1.5e-7)
 }

--- a/inst/unitTests/runit.cube.R
+++ b/inst/unitTests/runit.cube.R
@@ -42,25 +42,6 @@ test.cube <- function() {
               tolerance = 1.5e-7)
   
   
-  ## modify test objects to contain NA value
-  dbl_cube[2, 2, 2] <- NA
-  int_cube[2, 2, 2] <- NA
-  cplx_cube[2, 2, 2] <- NA
-  
-  ## check cube (Cube<double>) and fcube (Cube<float>), with NAs
-  checkEquals(cube_test(dbl_cube), (dbl_cube ** 2), "cube_test with NA")
-  checkEquals(fcube_test(dbl_cube), (dbl_cube ** 2), "fcube_test with NA")
-  
-  ## check icube (Cube<sword>) and ucube (Cube<uword>), with NAs
-  checkEquals(icube_test(int_cube), (int_cube ** 2), "icube_test with NA")
-  checkEquals(ucube_test(int_cube), (int_cube ** 2), "ucube_test with NA")
-  
-  ## check cx_cube (Cube<cx_double>) and cx_fcube (Cube<cx_float>), with NAs
-  checkEquals(cx_cube_test(cplx_cube), (cplx_cube ** 2), "cx_cube_test with NA")
-  checkEquals(cx_fcube_test(cplx_cube), (cplx_cube ** 2), "cx_fcube_test with NA",
-              tolerance = 1.5e-7)
-  
-  
   ## test that exception is thrown with dims(x) != 3
   dbl_cube <- array(1.5:16.5, rep(2, 4))
   int_cube <- array(1L:16L, rep(2, 4))

--- a/inst/unitTests/runit.cube.R
+++ b/inst/unitTests/runit.cube.R
@@ -1,0 +1,92 @@
+#!/usr/bin/r -t
+#
+# Copyright (C) 2015 Dirk Eddelbuettel and Nathan Russell
+#
+# This file is part of RcppArmadillo.
+#
+# RcppArmadillo is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# RcppArmadillo is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RcppArmadillo.  If not, see <http://www.gnu.org/licenses/>.
+
+# 30 November 2015
+
+.setUp <- RcppArmadillo:::unit_test_setup("cube.cpp")
+
+test.cube <- function() {
+  
+  ## test arrays
+  dbl_cube <- array(1.5:27.5, rep(3, 3))
+  int_cube <- array(1L:27L, rep(3, 3))
+  cplx_cube <- array(1.5:27.5 + 2i, rep(3, 3))
+  
+  ## check cube (Cube<double>) and fcube (Cube<float>), no NAs
+  checkEquals(cube_test(dbl_cube), (dbl_cube ** 2), "cube_test no NA")
+  checkEquals(fcube_test(dbl_cube), (dbl_cube ** 2), "fcube_test no NA")
+  
+  ## check icube (Cube<sword>) and ucube (Cube<uword>), no NAs
+  checkEquals(icube_test(int_cube), (int_cube ** 2), "icube_test no NA")
+  checkEquals(ucube_test(int_cube), (int_cube ** 2), "ucube_test no NA")
+  
+  ## check cx_cube (Cube<cx_double>) and cx_fcube (Cube<cx_float>), no NAs
+  checkEquals(cx_cube_test(cplx_cube), (cplx_cube ** 2), "cx_cube_test no NA")
+  checkEquals(cx_fcube_test(cplx_cube), (cplx_cube ** 2), "cx_fcube_test no NA",
+              tolerance = 1.5e-7)
+  
+  
+  ## modify test objects to contain NA value
+  dbl_cube[2, 2, 2] <- NA
+  int_cube[2, 2, 2] <- NA
+  cplx_cube[2, 2, 2] <- NA
+  
+  ## check cube (Cube<double>) and fcube (Cube<float>), with NAs
+  checkEquals(cube_test(dbl_cube), (dbl_cube ** 2), "cube_test with NA")
+  checkEquals(fcube_test(dbl_cube), (dbl_cube ** 2), "fcube_test with NA")
+  
+  ## check icube (Cube<sword>) and ucube (Cube<uword>), with NAs
+  checkEquals(icube_test(int_cube), (int_cube ** 2), "icube_test with NA")
+  checkEquals(ucube_test(int_cube), (int_cube ** 2), "ucube_test with NA")
+  
+  ## check cx_cube (Cube<cx_double>) and cx_fcube (Cube<cx_float>), with NAs
+  checkEquals(cx_cube_test(cplx_cube), (cplx_cube ** 2), "cx_cube_test with NA")
+  checkEquals(cx_fcube_test(cplx_cube), (cplx_cube ** 2), "cx_fcube_test with NA",
+              tolerance = 1.5e-7)
+  
+  
+  ## test that exception is thrown with dims(x) != 3
+  dbl_cube <- array(1.5:16.5, rep(2, 4))
+  int_cube <- array(1L:16L, rep(2, 4))
+  cplx_cube <- array(1.5:16.5 + 2i, rep(2, 4))
+  
+  ## cube_test and fcube_test should throw here
+  checkTrue(
+    inherits(try(cube_test(dbl_cube), silent = TRUE), "try-error"),
+    "cube_test bad dimensions")
+  checkTrue(
+    inherits(try(fcube_test(dbl_cube), silent = TRUE), "try-error"),
+    "fcube_test bad dimensions")
+  
+  ## icube_test and ucube_test should throw here
+  checkTrue(
+    inherits(try(icube_test(int_cube), silent = TRUE), "try-error"),
+    "icube_test bad dimensions")
+  checkTrue(
+    inherits(try(ucube_test(int_cube), silent = TRUE), "try-error"),
+    "ucube_test bad dimensions")
+  
+  ## cx_cube_test and cx_fcube_test should throw here
+  checkTrue(
+    inherits(try(cx_cube_test(cplx_cube), silent = TRUE), "try-error"),
+    "cx_cube_test bad dimensions")
+  checkTrue(
+    inherits(try(cx_fcube_test(cplx_cube), silent = TRUE), "try-error"),
+    "cx_fcube_test bad dimensions")
+}


### PR DESCRIPTION
As discussed in #63 this extends `Rcpp::as<>` for use with Armadillo's templated `Cube` class.