### PR TITLE
Allowing ARMA_64BIT_WORD if required

### DIFF
--- a/inst/include/RcppArmadilloAs.h
+++ b/inst/include/RcppArmadilloAs.h
@@ -91,25 +91,47 @@ namespace traits {
             IntegerVector p = mat.slot("p") ;     
             Vector<RTYPE> x = mat.slot("x") ;
                         
-            arma::SpMat<T> res(dims[0], dims[1]);
-                        
-            // create space for values, copy and set sentinel
-            arma::access::rw(res.values) = arma::memory::acquire_chunked<T>(x.size() + 1);
-            arma::arrayops::copy(arma::access::rwp(res.values), x.begin(), x.size());
-            arma::access::rw(res.values[x.size()]) = T(0.0);                    // sets sentinel
-
-            // create space for row_indices, copy and set sentinel
-            arma::access::rw(res.row_indices) = arma::memory::acquire_chunked<arma::uword>(i.size() + 1);
-            std::copy(i.begin(), i.end(), arma::access::rwp(res.row_indices)); 
-            arma::access::rw(res.values[i.size()]) = arma::uword(0);            // sets sentinel
-
-            // the space for col_ptrs is already initialized when we call the
-            // constructor a few lines above so we only need to fill the appropriate
-            // values, and the sentinel is already set to uword_max as well.
+            // arma::SpMat<T> res(dims[0], dims[1]);
+            arma::SpMat<T> res((unsigned) dims[0], (unsigned) dims[1]);
+            
+            // Resizing
+            res.mem_resize((unsigned) x.size());
+            
+            // Copying elements
+            std::copy(i.begin(), i.end(), arma::access::rwp(res.row_indices));
             std::copy(p.begin(), p.end(), arma::access::rwp(res.col_ptrs));
-                        
-            // set the number of non-zero elements
-            arma::access::rw(res.n_nonzero) = x.size();
+            std::copy(x.begin(), x.end(), arma::access::rwp(res.values));
+            
+            // Setting the sentinel
+            arma::access::rw(res.col_ptrs[(unsigned) dims[1] + 1]) =
+              std::numeric_limits<arma::uword>::max();
+              
+            // // create space for values, copy and set sentinel
+            // arma::access::rw(res.values) = arma::memory::acquire_chunked<T>(x.size() + 1);
+            // arma::arrayops::copy(arma::access::rwp(res.values), x.begin(), x.size());
+            // arma::access::rw(res.values[x.size()]) = T(0.0);                    // sets sentinel
+            // 
+            // // create space for row_indices, copy and set sentinel
+            // arma::access::rw(res.row_indices) = arma::memory::acquire_chunked<arma::uword>(i.size() + 1);
+            // std::copy(i.begin(), i.end(), arma::access::rwp(res.row_indices));
+            // arma::access::rw(res.values[i.size()]) = arma::uword(0);            // sets sentinel
+            // 
+            // // the space for col_ptrs is already initialized when we call the
+            // // constructor a few lines above so we only need to fill the appropriate
+            // // values, and the sentinel is already set to uword_max as well.
+            // std::copy(p.begin(), p.end(), arma::access::rwp(res.col_ptrs));
+            // 
+            // // set the number of non-zero elements
+            // arma::access::rw(res.n_nonzero) = x.size();
+            
+            // // Using BATCH constructor
+            // arma::SpMat<T> res(
+            //     Rcpp::as< arma::uvec >(i),
+            //     Rcpp::as< arma::uvec >(p),
+            //     Rcpp::as< arma::Col<T> >(x),
+            //     (unsigned) dims[0],
+            //     (unsigned) dims[1]
+            // );
                         
             return res;
         }

--- a/inst/include/RcppArmadilloConfig.h
+++ b/inst/include/RcppArmadilloConfig.h
@@ -100,7 +100,9 @@
 // Under C++11 and C++14, Armadillo now defaults to using int64_t for
 // integers.  This prevents us from passing integer vectors to R as
 // only used int32_t -- so we select the shorter representation here.
-#define ARMA_32BIT_WORD 1
+#if !defined(ARMA_64BIT_WORD)
+  #define ARMA_32BIT_WORD 1
+#endif
 
 #endif
 

--- a/inst/include/RcppArmadilloConfig.h
+++ b/inst/include/RcppArmadilloConfig.h
@@ -100,9 +100,7 @@
 // Under C++11 and C++14, Armadillo now defaults to using int64_t for
 // integers.  This prevents us from passing integer vectors to R as
 // only used int32_t -- so we select the shorter representation here.
-#if !defined(ARMA_64BIT_WORD)
-  #define ARMA_32BIT_WORD 1
-#endif
+#define ARMA_32BIT_WORD 1
 
 #endif
 

--- a/inst/include/RcppArmadilloConfig.h
+++ b/inst/include/RcppArmadilloConfig.h
@@ -100,7 +100,10 @@
 // Under C++11 and C++14, Armadillo now defaults to using int64_t for
 // integers.  This prevents us from passing integer vectors to R as
 // only used int32_t -- so we select the shorter representation here.
-#define ARMA_32BIT_WORD 1
+// unless int64_t is explicitly required during compilation.
+#if !defined(ARMA_64BIT_WORD)
+  #define ARMA_32BIT_WORD 1
+#endif
 
 #endif
 

--- a/inst/include/armadillo_bits/config.hpp
+++ b/inst/include/armadillo_bits/config.hpp
@@ -187,7 +187,7 @@
   #undef ARMA_USE_EXTERN_CXX11_RNG
 #endif
 
-#if defined(ARMA_32BIT_WORD) && !defined(ARMA_64BIT_WORD)
+#if defined(ARMA_32BIT_WORD)
   #undef ARMA_64BIT_WORD
 #endif
 


### PR DESCRIPTION
Following this discussion http://lists.r-forge.r-project.org/pipermail/rcpp-devel/2016-April/009225.html developers using RcppArmadillo can now pass -DARMA_64BIT_WORD to change the default ARMA_32BIT_WORD. This is useful in case that the user needs to work with objects (matrices/vectors) holding more than 4 billion objects (e.g. Sparse Matrix used as an adjacency matrix for a social network). This will be tested in https://github.com/gvegayon/arma64bit.