### PR TITLE
Fixing bug in SpMat exporter

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,9 +1,9 @@
 2016-05-04  George G. Vega Yon  <g.vegayon@gmail.com>
 
-        * DESCRIPTION: Release 0.6.700.6.0 [GitHub only]
-        * inst/NEWS.Rd: Release 0.6.700.6.0 [GitHub only]
-
 	* inst/include/RcppArmadilloConfig.h: Added support for int64_t when required
+	* inst/include/RcppArmadilloAs.h: Fixing bug in SpMat exporter
+	* inst/unitTests/cpp/sparse.cpp: Added two new tests
+	* inst/unitTests/runit.sparse.R: Added two new tests
 	
 2016-05-03  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -14,8 +14,8 @@
       \item corrected documentation for the \code{solve()} function
     }
     \item Added support for \code{int64_t} (\code{ARMA_64BIT_WORD}) when required during compilation time.
-    (PR \ghpr{89} by George G. Vega Yon, fixing \ghpr{88})
-    \item Fixed bug in \code{SpMat} exporter (PR \ghpr{90} by George G. Vega Yon,
+    (PR \ghpr{90} by George G. Vega Yon, fixing \ghpr{88})
+    \item Fixed bug in \code{SpMat} exporter (PR \ghpr{91} by George G. Vega Yon,
     fixing \ghit{89} and \ghit{72})
   }
 }

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -13,8 +13,10 @@
       \item fix for gcc-6.1 warning about misleading indentation
       \item corrected documentation for the \code{solve()} function
     }
-    \item Added support for \code{int64_t} when required during compilation time.
+    \item Added support for \code{int64_t} (\code{ARMA_64BIT_WORD}) when required during compilation time.
     (PR \ghpr{89} by George G. Vega Yon, fixing \ghpr{88})
+    \item Fixed bug in \code{SpMat} exporter (PR \ghpr{90} by George G. Vega Yon,
+    fixing \ghit{89} and \ghit{72})
   }
 }
 

--- a/inst/include/RcppArmadilloAs.h
+++ b/inst/include/RcppArmadilloAs.h
@@ -90,26 +90,21 @@ namespace traits {
             IntegerVector i = mat.slot("i") ;
             IntegerVector p = mat.slot("p") ;     
             Vector<RTYPE> x = mat.slot("x") ;
-                        
-            arma::SpMat<T> res(dims[0], dims[1]);
-                        
-            // create space for values, copy and set sentinel
-            arma::access::rw(res.values) = arma::memory::acquire_chunked<T>(x.size() + 1);
-            arma::arrayops::copy(arma::access::rwp(res.values), x.begin(), x.size());
-            arma::access::rw(res.values[x.size()]) = T(0.0);                    // sets sentinel
-
-            // create space for row_indices, copy and set sentinel
-            arma::access::rw(res.row_indices) = arma::memory::acquire_chunked<arma::uword>(i.size() + 1);
-            std::copy(i.begin(), i.end(), arma::access::rwp(res.row_indices)); 
-            arma::access::rw(res.values[i.size()]) = arma::uword(0);            // sets sentinel
-
-            // the space for col_ptrs is already initialized when we call the
-            // constructor a few lines above so we only need to fill the appropriate
-            // values, and the sentinel is already set to uword_max as well.
+            
+            // Creating an empty SpMat            
+            arma::SpMat<T> res((unsigned) dims[0], (unsigned) dims[1]);
+            
+            // Making space for the elements
+            res.mem_resize((unsigned) x.size());
+            
+            // Copying elements
+            std::copy(i.begin(), i.end(), arma::access::rwp(res.row_indices));
             std::copy(p.begin(), p.end(), arma::access::rwp(res.col_ptrs));
-                        
-            // set the number of non-zero elements
-            arma::access::rw(res.n_nonzero) = x.size();
+            std::copy(x.begin(), x.end(), arma::access::rwp(res.values));
+            
+            // Setting the sentinel
+            arma::access::rw(res.col_ptrs[(unsigned) dims[1] + 1]) =
+              std::numeric_limits<arma::uword>::max();
                         
             return res;
         }

--- a/inst/unitTests/cpp/sparse.cpp
+++ b/inst/unitTests/cpp/sparse.cpp
@@ -58,3 +58,22 @@ arma::sp_mat sparseSqrt(arma::sp_mat SM) {
 arma::sp_mat sparseSquare(arma::sp_mat SM) {
     return arma::square(SM);
 }
+
+// [[Rcpp::export]]
+arma::sp_mat sparseIterators(arma::sp_mat SM, double val) {
+    arma::sp_mat::iterator begin = SM.begin();
+    arma::sp_mat::iterator end   = SM.end();
+    
+    for (arma::sp_mat::iterator it = begin; it != end; ++it)
+      (*it) += val;
+    
+    return SM;
+}
+
+// [[Rcpp::export]]
+Rcpp::List sparseList(Rcpp::List l) {
+    arma::sp_mat mat1 = l[0];
+    arma::sp_mat mat2 = l[0];
+    
+    return Rcpp::List::create(mat1, mat2);
+}

--- a/inst/unitTests/runit.sparse.R
+++ b/inst/unitTests/runit.sparse.R
@@ -74,5 +74,22 @@ if (.runThisTest) {
     test.sparse.square <- function() {
         checkEquals(SM^2, sparseSquare(SM), msg="squareSparse")
     }
+    
+    test.sparse.iterators <- function() {
+        SM <- matrix(0, 5, 5)
+        diag(SM) <- 1:5
+        SM <- methods::as(SM, "dgCMatrix")
+        spM <- sparseIterators(SM, -1.5)
+        diag(SM) <- diag(SM) - 1.5
+        checkEquals(SM, spM, msg="sparseIterators")
+    }
+    
+    test.sparse.list <- function() {
+        SM <- matrix(0, 5, 5)
+        diag(SM) <- 1:5
+        SM <- methods::as(SM, "dgCMatrix")
+        l  <- list(SM, SM)
+        checkEquals(l, sparseList(l), msg="sparseList")
+    }
    
 }


### PR DESCRIPTION
Solves issue https://github.com/RcppCore/RcppArmadillo/issues/89 as well as issue https://github.com/RcppCore/RcppArmadillo/issues/72. RcppArmadillo was compiled and checked with Valgrind and no memory leaks (or issues with `Conditional jump...`) where detected (nor in the examples, vignettes or tests). Also includes two new tests used to explicitly detect the two issues mentioned when using `R CMD check --use-valgrind`.