### PR TITLE
Force a deep copy in as<arma::Cube>(x) as in vec/mat cases

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2016-09-23  Jouni Helske  <jouni.helske@jyu.fi>
+
+	* inst/include/RcppArmadilloAs.h: as<arma::Cube> always 
+	makes a copy as the vec/mat cases.
+	* inst/include/RcppArmadilloForward.h: Ditto.
+	
 2016-08-24  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version): Release 0.7.400.2.0 (CRAN)

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,7 +3,9 @@
 	* inst/include/RcppArmadilloAs.h: as<arma::Cube> always 
 	makes a copy as the vec/mat cases.
 	* inst/include/RcppArmadilloForward.h: Ditto.
-	
+	* inst/unitTests/cpp/cube.cpp: More unit tests for cubes
+	* inst/unitTests/runit.cube.R: Ditto.
+		
 2016-08-24  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version): Release 0.7.400.2.0 (CRAN)

--- a/inst/include/RcppArmadilloAs.h
+++ b/inst/include/RcppArmadilloAs.h
@@ -118,10 +118,7 @@ namespace traits {
     // handles cube, icube, and cx_cube
     // fails on fcube, ucube, and cx_fcube
     
-    // 23 September 2016
-    // Modified the Cube-exported to take account const ref
-    
-    //non-const ref case, make a copy
+    //make a copy when using as<arma::cube> like in vec/mat cases
     template <typename T>
     class Exporter< arma::Cube<T> > {
     public:
@@ -130,7 +127,7 @@ namespace traits {
         typedef typename Rcpp::traits::storage_type<RTYPE>::type value_t;
         Exporter(SEXP x) : vec(x) {}
       
-        cube_t get() {
+        cube_t get(bool copy = true) {
             Rcpp::Vector<INTSXP> dims = vec.attr("dim");
             if (dims.size() != 3) {
                 std::string msg = 
@@ -141,7 +138,7 @@ namespace traits {
           
             cube_t result(
                 reinterpret_cast<T*>(vec.begin()),
-                dims[0], dims[1], dims[2], true);
+                dims[0], dims[1], dims[2], copy);
             return result;
         }
       
@@ -149,33 +146,6 @@ namespace traits {
         Rcpp::Vector<RTYPE> vec;
     };
     
-    // const ref
-    template <typename T>
-    class Exporter< const arma::Cube<T>& > {
-    public:
-        typedef arma::Cube<T> cube_t;
-        enum { RTYPE = Rcpp::traits::r_sexptype_traits<T>::rtype };
-        typedef typename Rcpp::traits::storage_type<RTYPE>::type value_t;
-        Exporter(SEXP x) : vec(x) {}
-      
-        cube_t get() {
-            Rcpp::Vector<INTSXP> dims = vec.attr("dim");
-            if (dims.size() != 3) {
-                std::string msg = 
-                  "Error converting object to arma::Cube<T>:\n"
-                  "Input array must have exactly 3 dimensions.\n";
-                Rcpp::stop(msg);
-            }
-          
-            cube_t result(
-                reinterpret_cast<T*>(vec.begin()),
-                dims[0], dims[1], dims[2], false);
-            return result;
-        }
-      
-    private:
-        Rcpp::Vector<RTYPE> vec;
-    };
     // specializations for 3 cube typedefs that fail above
     // first use viable conversion SEXP -> Cube<other_t>
     // then use conv_to<cube_t>::from(other_t other)
@@ -185,7 +155,7 @@ namespace traits {
         typedef arma::fcube cube_t;
         
         Exporter(SEXP x)
-            : tmp(Exporter<arma::cube>(x).get()) {}
+            : tmp(Exporter<arma::cube>(x).get(false)) {}
         
         cube_t get() {
             cube_t result = arma::conv_to<cube_t>::from(tmp);
@@ -203,7 +173,7 @@ namespace traits {
         typedef arma::ucube cube_t;
       
         Exporter(SEXP x)
-            : tmp(Exporter<arma::icube>(x).get()) {}
+            : tmp(Exporter<arma::icube>(x).get(false)) {}
         
         cube_t get() {
             cube_t result = arma::conv_to<cube_t>::from(tmp);
@@ -221,7 +191,7 @@ namespace traits {
         typedef arma::cx_fcube cube_t;
       
         Exporter(SEXP x)
-            : tmp(Exporter<arma::cx_cube>(x).get()) {}
+            : tmp(Exporter<arma::cx_cube>(x).get(false)) {}
       
         cube_t get() {
             cube_t result = arma::conv_to<cube_t>::from(tmp);
@@ -316,7 +286,14 @@ namespace traits {
     class ArmaCube_InputParameter<T, CUBE, REF, Rcpp::traits::false_type> {
     public:
       ArmaCube_InputParameter( SEXP x_ ) : c(x_), dims(c.attr("dim")), cube( reinterpret_cast<T*>( c.begin() ), 
-        dims[0], dims[1], dims[2], false ) {}
+        dims[0], dims[1], dims[2], false ) {
+            if (dims.size() != 3) {
+                std::string msg = 
+                  "Error converting object to arma::Cube<T>:\n"
+                  "Input array must have exactly 3 dimensions.\n";
+                Rcpp::stop(msg);
+            }
+      }
       
       inline operator REF(){
         return cube ;        

--- a/inst/include/RcppArmadilloAs.h
+++ b/inst/include/RcppArmadilloAs.h
@@ -381,7 +381,7 @@ namespace traits {
     class INPUT_TYPE<TYPE> : public ArmaCube_InputParameter<T, TYPE, REF >{  \
       public:                                                               \
         INPUT_TYPE( SEXP x) : ArmaCube_InputParameter<T, TYPE, REF >(x){}    \
-    } ;                                                                                                                  
+    } ;                                                                                                                 
     
     MAKE_INPUT_PARAMETER(ConstReferenceInputParameter, arma::Cube<T>, const arma::Cube<T>& )
     MAKE_INPUT_PARAMETER(ReferenceInputParameter     , arma::Cube<T>, arma::Cube<T>&       )

--- a/inst/include/RcppArmadilloForward.h
+++ b/inst/include/RcppArmadilloForward.h
@@ -105,6 +105,10 @@ namespace Rcpp {
 
     } // namespace traits 
 
+    template <typename T> class ConstReferenceInputParameter< arma::Cube<T> > ;
+    template <typename T> class ReferenceInputParameter< arma::Cube<T> > ;
+    template <typename T> class ConstInputParameter< arma::Cube<T> > ;
+    
     template <typename T> class ConstReferenceInputParameter< arma::Mat<T> > ;
     template <typename T> class ReferenceInputParameter< arma::Mat<T> > ;
     template <typename T> class ConstInputParameter< arma::Mat<T> > ;

--- a/inst/unitTests/cpp/cube.cpp
+++ b/inst/unitTests/cpp/cube.cpp
@@ -89,3 +89,25 @@ arma::cx_fcube as_cx_fcube(Rcpp::ComplexVector x) {
   arma::cx_fcube y = Rcpp::as<arma::cx_fcube>(x);
   return arma::pow(y, 2);
 }
+
+// [[Rcpp::export]]
+void as_cube_copy(Rcpp::NumericVector x) {
+  arma::cube y(Rcpp::as<arma::cube>(x));
+  y(0) = 111.0;
+}
+
+// [[Rcpp::export]]
+void as_fcube_copy(Rcpp::NumericVector x) {
+  arma::fcube y(Rcpp::as<arma::fcube>(x));
+  y(0) = 111.0;
+}
+
+// [[Rcpp::export]]
+void cube_no_copy(arma::cube& x) {
+  x(0) = 111.0;
+}
+
+// [[Rcpp::export]]
+void fcube_no_copy(arma::fcube& x) {
+  x(0) = 111.0;
+}

--- a/inst/unitTests/runit.cube.R
+++ b/inst/unitTests/runit.cube.R
@@ -89,4 +89,27 @@ test.cube <- function() {
   checkEquals(as_cx_cube(cplx_cube), (cplx_cube ** 2), "as_cx_cube")
   checkEquals(as_cx_fcube(cplx_cube), (cplx_cube ** 2), "as_cx_fcube",
               tolerance = 1.5e-7)
+  
+  
+  ## check that deep copying works for doubles
+  dbl_cube <- array(0.1 + 1:8, rep(2, 3))
+  as_cube_copy(dbl_cube)
+  checkEquals(dbl_cube, array(0.1 + 1:8, rep(2, 3)), "as_deep_copy")
+  dbl_cube <- array(0.1 + 1:8, rep(2, 3))
+  cube_no_copy(dbl_cube)
+  checkEquals(dbl_cube, array(c(111, 0.1 + 2:8), rep(2, 3)), "no_deep_copy")
+  #deep copy due to conversion from int -> double
+  dbl_cube <- array(1L:8L, rep(2, 3))
+  cube_no_copy(dbl_cube)
+  checkEquals(dbl_cube, array(1L:8L, rep(2, 3)), "conv_deep_copy")
+  
+  ## check that deep copying works for floats
+  dbl_cube <- array(0.1 + 1:8, rep(2, 3))
+  as_fcube_copy(dbl_cube)
+  checkEquals(dbl_cube, array(0.1 + 1:8, rep(2, 3)), "f_as_deep_copy")
+  dbl_cube <- array(0.1 + 1:8, rep(2, 3))
+  #deep copy due to conversion from double -> float
+  fcube_no_copy(dbl_cube)
+  checkEquals(dbl_cube, array(0.1 + 1:8, rep(2, 3)), "f_conv_deep_copy")
+  
 }


### PR DESCRIPTION
This PR tries to fix the issue discussed on the Rcpp-list, now a copy of x is always made when using as<>() for Cube, just like in case of vector and matrices.

The old and few new unit tests seems to pass fine, but to be honest I pretty much mimicked the codes from vec/mat case without deep understanding what I did, so... ;)