### PR TITLE
update license for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ Romain Francois, Dirk Eddelbuettel and Doug Bates
 
 ### License
 
-GPL (>= 2)
+GPL (>= 3)


### PR DESCRIPTION
Apache 2.0 license is compatible with GPL 3.
https://en.wikipedia.org/wiki/Apache_License#GPL_compatibility
"... The Free Software Foundation considers all versions of the Apache License to be incompatible with the previous GPL versions 1 and 2 ..."