### PR TITLE
update license for compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Description: 'Armadillo' is a templated C++ linear algebra library (by Conrad
  the GNU GPL version 2 or later, as is the rest of 'Rcpp'. Note that
  Armadillo requires a fairly recent compiler; for the g++ family at least
  version 4.6.* is required. 
-License: GPL (>= 2)
+License: GPL (>= 3)
 LazyLoad: yes
 LinkingTo: Rcpp
 Imports: Rcpp (>= 0.11.0), stats, utils


### PR DESCRIPTION
Apache 2.0 license is compatible with GPL 3.
https://en.wikipedia.org/wiki/Apache_License#GPL_compatibility
"... The Free Software Foundation considers all versions of the Apache License to be incompatible with the previous GPL versions 1 and 2 ..."