### PR TITLE
Fix the problem in slot "p" in "dgCMatrix". close #149

### DIFF
--- a/inst/include/armadillo_bits/SpMat_meat.hpp
+++ b/inst/include/armadillo_bits/SpMat_meat.hpp
@@ -3392,6 +3392,12 @@ SpMat<eT>::eye(const uword in_rows, const uword in_cols)
   
   for(uword i = 0; i <= N; ++i) { access::rw(col_ptrs[i])    = i; }
   
+  // take into account non-square matrices
+  for(uword i = (N+1); i <= in_cols; ++i)
+    {
+    access::rw(col_ptrs[i]) += col_ptrs[i - 1];
+    }
+
   access::rw(n_nonzero) = N;
   
   return *this;

--- a/inst/unitTests/cpp/sparse.cpp
+++ b/inst/unitTests/cpp/sparse.cpp
@@ -77,3 +77,8 @@ Rcpp::List sparseList(Rcpp::List l) {
     
     return Rcpp::List::create(mat1, mat2);
 }
+
+// [[Rcpp::export]]
+arma::sp_mat speye(int nrow, int ncol) {
+    return arma::speye(nrow, ncol);
+}

--- a/inst/unitTests/runit.sparse.R
+++ b/inst/unitTests/runit.sparse.R
@@ -90,4 +90,16 @@ if (.runThisTest) {
         l  <- list(SM, SM)
         checkEquals(l, sparseList(l), msg="sparseList")
     }
+    
+    test.speye <- function() {
+      SM <- speye(4, 4)
+      SM2 <- sparseMatrix(i = c(1:4), j = c(1:4), x = 1)
+      checkEquals(SM, SM2, msg="speye")
+      SM <- speye(3, 5)
+      SM2 <- sparseMatrix(i = c(1:3), j = c(1:3), x = 1, dims = c(3, 5))
+      checkEquals(SM, SM2, msg="speye")
+      SM <- speye(5, 3)
+      SM2 <- sparseMatrix(i = c(1:3), j = c(1:3), x = 1, dims = c(5, 3))
+      checkEquals(SM, SM2, msg="speye")
+    }
 }


### PR DESCRIPTION
__Please don't merge this. I need to double check the definition of slot "p" and "col_ptrs".__

Before this PR:

```cpp

#include <RcppArmadillo.h>
// [[Rcpp::depends(RcppArmadillo)]]
//
using namespace Rcpp;
using namespace arma;

//[[Rcpp::export]]
sp_mat test() {
  return speye(4, 5);
}

/*
> Rcpp::sourceCpp("test.cpp")
> library(Matrix)
> test()
4 x 5 sparse Matrix of class "dgCMatrix"
Error in validObject(x) : 
  invalid class “dgCMatrix” object: slot p must be non-decreasing
*/
```

Now:

```r
> Rcpp::sourceCpp("test.cpp")
> library(Matrix)
> test()
4 x 5 sparse Matrix of class "dgCMatrix"
              
[1,] 1 . . . .
[2,] . 1 . . .
[3,] . . 1 . .
[4,] . . . 1 .
```

