### PR TITLE
added optional RCPP_ARMADILLO_RETURN_COLVEC_AS_VECTOR and co.

### DIFF
--- a/R/unit.test.R
+++ b/R/unit.test.R
@@ -35,12 +35,14 @@ unit_test_setup <- function(file = NULL, packages = NULL) {
             }
         }
         if (!is.null(file)) {
-            if (exists("pathRcppArmadilloTests")) {
-                sourceCpp(file.path(get("pathRcppArmadilloTests"), "cpp", file))
-            } else if (file.exists(file.path("cpp", file))) {
-                sourceCpp(file.path( "cpp", file))
-            } else {
-                sourceCpp(system.file("unitTests", "cpp", file, package="RcppArmadillo"))
+            for (f in file) {
+                if (exists("pathRcppArmadilloTests")) {
+                    sourceCpp(file.path(get("pathRcppArmadilloTests"), "cpp", f))
+                } else if (file.exists(file.path("cpp", f))) {
+                    sourceCpp(file.path( "cpp", f))
+                } else {
+                    sourceCpp(system.file("unitTests", "cpp", f, package="RcppArmadillo"))
+                }
             }
         }
     }

--- a/inst/include/RcppArmadilloWrap.h
+++ b/inst/include/RcppArmadilloWrap.h
@@ -62,11 +62,19 @@ namespace Rcpp{
     }
 
     template <typename T> SEXP wrap( const arma::Col<T>& data ){
+#if defined(RCPP_ARMADILLO_RETURN_COLVEC_AS_VECTOR) || defined(RCPP_ARMADILLO_RETURN_ANYVEC_AS_VECTOR)
+        return RcppArmadillo::arma_wrap( data ) ;
+#else
         return RcppArmadillo::arma_wrap( data, Dimension( data.n_elem, 1) ) ;
+#endif
     }
 
     template <typename T> SEXP wrap( const arma::Row<T>& data ){
+#if defined(RCPP_ARMADILLO_RETURN_ROWVEC_AS_VECTOR) || defined(RCPP_ARMADILLO_RETURN_ANYVEC_AS_VECTOR)
+        return RcppArmadillo::arma_wrap( data ) ;
+#else
         return RcppArmadillo::arma_wrap(data, Dimension( 1, data.n_elem ) ) ;
+#endif
     }
 
     template <typename T> SEXP wrap( const arma::Cube<T>& data ){

--- a/inst/unitTests/cpp/any_as_vec.cpp
+++ b/inst/unitTests/cpp/any_as_vec.cpp
@@ -1,0 +1,11 @@
+// [[Rcpp::depends(RcppArmadillo)]]
+#define RCPP_ARMADILLO_RETURN_ANYVEC_AS_VECTOR
+
+#include <RcppArmadillo.h>
+
+using namespace Rcpp;
+
+// [[Rcpp::export]]
+arma::vec veccany_as_v_test(arma::vec v) { return(v); }
+// [[Rcpp::export]]
+arma::rowvec vecrany_as_v_test(arma::rowvec v) { return(v); }

--- a/inst/unitTests/cpp/armadillo.cpp
+++ b/inst/unitTests/cpp/armadillo.cpp
@@ -295,3 +295,9 @@ arma::umat r_umat_test(arma::umat& v) { return(v); }
 
 // [[Rcpp::export]]
 arma::umat cr_umat_test(const arma::umat& v) { return(v); }
+
+// [[Rcpp::export]]
+arma::vec vecc_test(arma::vec v) { return(v); }
+
+// [[Rcpp::export]]
+arma::rowvec vecr_test(arma::rowvec v) { return(v); }

--- a/inst/unitTests/cpp/colrow_as_vec.cpp
+++ b/inst/unitTests/cpp/colrow_as_vec.cpp
@@ -1,0 +1,11 @@
+// [[Rcpp::depends(RcppArmadillo)]]
+#define RCPP_ARMADILLO_RETURN_COLVEC_AS_VECTOR
+#define RCPP_ARMADILLO_RETURN_ROWVEC_AS_VECTOR
+#include <RcppArmadillo.h>
+
+using namespace Rcpp;
+
+// [[Rcpp::export]]
+arma::vec vecc_as_v_test(arma::vec v) { return(v); }
+// [[Rcpp::export]]
+arma::rowvec vecr_as_v_test(arma::rowvec v) { return(v); }

--- a/inst/unitTests/runit.RcppArmadillo.R
+++ b/inst/unitTests/runit.RcppArmadillo.R
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with RcppArmadillo.  If not, see <http://www.gnu.org/licenses/>.
 
-.setUp <- RcppArmadillo:::unit_test_setup( "armadillo.cpp", "RcppArmadillo" )
+.setUp <- RcppArmadillo:::unit_test_setup( c("armadillo.cpp", "colrow_as_vec.cpp", "any_as_vec.cpp"), "RcppArmadillo" )
 
 test.wrap.R <- function(){
     fx <- wrap_
@@ -236,4 +236,15 @@ test.armadillo.unsigned.as <- function() {
     checkEquals(mat, c_umat_test(mat))
     checkEquals(mat, r_umat_test(mat))
     checkEquals(mat, cr_umat_test(mat))
+}
+test.armadillo.as_vector <- function() {
+    vec <- 1:3
+    vecc <- as.matrix(1:3)
+    vecr <- t(vecc)
+    checkEquals(vecc, vecc_test(vec), msg="legacy vec")
+    checkEquals(vecr, vecr_test(vecr), msg="legacy rowvec")
+    checkEquals(vec, vecc_as_v_test(vec), msg="vec as vector")
+    checkEquals(vec, vecr_as_v_test(vec), msg="rowvec as vector")
+    checkEquals(vec, veccany_as_v_test(vec), msg="vec (by any) as vector")
+    checkEquals(vec, vecrany_as_v_test(vec), msg="rowvec (by any) as vector")
 }


### PR DESCRIPTION
I don't know how to add unit tests with RUnit so tested by hand with code snipets like the following:

#### legacy colvec
```r
> sourceCpp(code="// [[Rcpp::depends(RcppArmadillo)]]\n#include <RcppArmadillo.h>\n// [[Rcpp::export]]\narma::vec add1(arma::vec x) {return(x+1);}")
> add1(1:2)
     [,1]
[1,]    2
[2,]    3
```

#### colvec tested with COLVEC
```r
> sourceCpp(code="// [[Rcpp::depends(RcppArmadillo)]]\n#define RCPP_ARMADILLO_RETURN_COLVEC_AS_VECTOR\n#include <RcppArmadillo.h>\n// [[Rcpp::export]]\narma::vec add1v(arma::vec x) {return(x+1);}")
> add1v(1:2)
[1] 2 3
```

#### colvec tested with ANYVEC
```r
> sourceCpp(code="// [[Rcpp::depends(RcppArmadillo)]]\n#define RCPP_ARMADILLO_RETURN_ANYVEC_AS_VECTOR\n#include <RcppArmadillo.h>\n// [[Rcpp::export]]\narma::vec add1v(arma::vec x) {return(x+1);}")
> add1v(1:2)
[1] 2 3
```

#### legacy rowvec
```r
> sourceCpp(code="// [[Rcpp::depends(RcppArmadillo)]]\n#include <RcppArmadillo.h>\n// [[Rcpp::export]]\narma::rowvec add1r(arma::rowvec x) {return(x+1);}")
> add1r(1:2)
     [,1] [,2]
[1,]    2    3
```

#### rowvec tested with ROWVEC
```r
> sourceCpp(code="// [[Rcpp::depends(RcppArmadillo)]]\n#define RCPP_ARMADILLO_RETURN_ROWVEC_AS_VECTOR\n#include <RcppArmadillo.h>\n// [[Rcpp::export]]\narma::rowvec add1rv(arma::rowvec x) {return(x+1);}")
> add1rv(1:2)
[1] 2 3
```

#### rowvec tested with ANYVEC
```r
> sourceCpp(code="// [[Rcpp::depends(RcppArmadillo)]]\n#define RCPP_ARMADILLO_RETURN_ANYVEC_AS_VECTOR\n#include <RcppArmadillo.h>\n// [[Rcpp::export]]\narma::rowvec add1rv(arma::rowvec x) {return(x+1);}")
> add1rv(1:2)
[1] 2 3
```

Signed-off-by: Serguei Sokol <sokol at insa-toulouse.fr>