### PR TITLE
Armadillo 8.100, call .sync() before accessing the internal arrays of the SpMat class

### DIFF
--- a/inst/include/RcppArmadilloAs.h
+++ b/inst/include/RcppArmadilloAs.h
@@ -105,6 +105,9 @@ namespace traits {
                 // Making space for the elements
                 res.mem_resize(static_cast<unsigned>(x.size()));
                 
+                // In order to access the internal arrays of the SpMat class
+                res.sync();
+                
                 // Copying elements
                 std::copy(i.begin(), i.end(), arma::access::rwp(res.row_indices));
                 std::copy(p.begin(), p.end(), arma::access::rwp(res.col_ptrs));
@@ -118,6 +121,9 @@ namespace traits {
                 
                 // Making space for the elements
                 res.mem_resize(static_cast<unsigned>(x.size()));
+                
+                // In order to access the internal arrays of the SpMat class
+                res.sync();
                 
                 // Copying elements
                 std::copy(i.begin(), i.end(), arma::access::rwp(res.row_indices));
@@ -136,6 +142,9 @@ namespace traits {
                 
                 // Making space for the elements
                 res.mem_resize(static_cast<unsigned>(x.size()));
+                
+                // In order to access the internal arrays of the SpMat class
+                res.sync();
                 
                 // Copying elements
                 std::copy(i.begin(), i.end(), arma::access::rwp(res.row_indices));
@@ -195,6 +204,9 @@ namespace traits {
                 // Making space for the elements
                 res.mem_resize(static_cast<unsigned>(x.size()));
                 
+                // In order to access the internal arrays of the SpMat class
+                res.sync();
+                
                 // Copying elements
                 std::copy(i.begin(), i.end(), arma::access::rwp(res.row_indices));
                 std::copy(p.begin(), p.end(), arma::access::rwp(res.col_ptrs));
@@ -247,6 +259,9 @@ namespace traits {
                 
                 // Making space for the elements
                 res.mem_resize(static_cast<unsigned>(x.size()));
+                
+                // In order to access the internal arrays of the SpMat class
+                res.sync();
                 
                 // Copying elements
                 std::copy(i.begin(), i.end(), arma::access::rwp(res.row_indices));
@@ -305,6 +320,9 @@ namespace traits {
                 // Making space for the elements
                 res.mem_resize(static_cast<unsigned>(x.size()));
                 
+                // In order to access the internal arrays of the SpMat class
+                res.sync();
+                
                 // Copying elements
                 std::copy(i.begin(), i.end(), arma::access::rwp(res.row_indices));
                 std::copy(p.begin(), p.end(), arma::access::rwp(res.col_ptrs));
@@ -361,6 +379,9 @@ namespace traits {
                 // Making space for the elements
                 res.mem_resize(static_cast<unsigned>(x.size()));
                 
+                // In order to access the internal arrays of the SpMat class
+                res.sync();
+                
                 // Copying elements
                 std::copy(i.begin(), i.end(), arma::access::rwp(res.row_indices));
                 std::copy(p.begin(), p.end(), arma::access::rwp(res.col_ptrs));
@@ -411,6 +432,9 @@ namespace traits {
                 
                 // Making space for the elements
                 res.mem_resize(static_cast<unsigned>(x.size()));
+                
+                // In order to access the internal arrays of the SpMat class
+                res.sync();
                 
                 // Copying elements
                 std::copy(i.begin(), i.end(), arma::access::rwp(res.row_indices));
@@ -467,6 +491,9 @@ namespace traits {
                 // Making space for the elements
                 res.mem_resize(static_cast<unsigned>(x.size()));
                 
+                // In order to access the internal arrays of the SpMat class
+                res.sync();
+                
                 // Copying elements
                 std::copy(i.begin(), i.end(), arma::access::rwp(res.row_indices));
                 std::copy(p.begin(), p.end(), arma::access::rwp(res.col_ptrs));
@@ -514,6 +541,9 @@ namespace traits {
                 // Making space for the elements
                 res.mem_resize(static_cast<unsigned>(x.size()));
                 
+                // In order to access the internal arrays of the SpMat class
+                res.sync();
+                
                 // Copying elements
                 std::copy(i.begin(), i.end(), arma::access::rwp(res.row_indices));
                 std::copy(p.begin(), p.end(), arma::access::rwp(res.col_ptrs));
@@ -544,6 +574,9 @@ namespace traits {
               
                 // Making space for the elements
                 res.mem_resize(static_cast<unsigned>(x.size()));
+                
+                // In order to access the internal arrays of the SpMat class
+                res.sync();
               
                 // Copying elements
                 std::copy(i.begin(), i.end(), arma::access::rwp(res.row_indices));
@@ -579,6 +612,9 @@ namespace traits {
 
                 // Making space for the elements
                 res.mem_resize(static_cast<unsigned>(x.size()));
+                
+                // In order to access the internal arrays of the SpMat class
+                res.sync();
 
                 // Copying elements
                 std::copy(i.begin(), i.end(), arma::access::rwp(res.row_indices));
@@ -588,6 +624,9 @@ namespace traits {
             else {
                 Rcpp::stop(type + " is not supported.");
             }
+            
+            // In order to access the internal arrays of the SpMat class
+            res.sync();
             
             // Setting the sentinel
             arma::access::rw(res.col_ptrs[static_cast<unsigned>(ncol + 1)]) =

--- a/inst/include/armadillo
+++ b/inst/include/armadillo
@@ -35,6 +35,7 @@
 #include <complex>
 #include <vector>
 #include <utility>
+#include <map>
 
 
 #if ( defined(__unix__) || defined(__unix) || defined(_POSIX_C_SOURCE) || (defined(__APPLE__) && defined(__MACH__)) ) && !defined(_WIN32)
@@ -168,6 +169,7 @@ namespace arma
   #include "armadillo_bits/SpRow_bones.hpp"
   #include "armadillo_bits/SpSubview_bones.hpp"
   #include "armadillo_bits/spdiagview_bones.hpp"
+  #include "armadillo_bits/MapMat_bones.hpp"
   
   #include "armadillo_bits/typedef_mat_fixed.hpp"
   
@@ -291,6 +293,7 @@ namespace arma
   #include "armadillo_bits/glue_hypot_bones.hpp"
   #include "armadillo_bits/glue_polyfit_bones.hpp"
   #include "armadillo_bits/glue_polyval_bones.hpp"
+  #include "armadillo_bits/glue_affmul_bones.hpp"
   
   #include "armadillo_bits/gmm_misc_bones.hpp"
   #include "armadillo_bits/gmm_diag_bones.hpp"
@@ -584,6 +587,7 @@ namespace arma
   #include "armadillo_bits/SpSubview_meat.hpp"
   #include "armadillo_bits/SpSubview_iterators_meat.hpp"
   #include "armadillo_bits/spdiagview_meat.hpp"
+  #include "armadillo_bits/MapMat_meat.hpp"
   
   #include "armadillo_bits/diskio_meat.hpp"
   #include "armadillo_bits/wall_clock_meat.hpp"
@@ -667,6 +671,7 @@ namespace arma
   #include "armadillo_bits/glue_hypot_meat.hpp"
   #include "armadillo_bits/glue_polyfit_meat.hpp"
   #include "armadillo_bits/glue_polyval_meat.hpp"
+  #include "armadillo_bits/glue_affmul_meat.hpp"
   
   #include "armadillo_bits/gmm_misc_meat.hpp"
   #include "armadillo_bits/gmm_diag_meat.hpp"

--- a/inst/include/armadillo_bits/Col_bones.hpp
+++ b/inst/include/armadillo_bits/Col_bones.hpp
@@ -171,8 +171,6 @@ class Col<eT>::fixed : public Col<eT>
   
   arma_align_mem eT mem_local_extra[ (use_extra) ? fixed_n_elem : 1 ];
   
-  arma_inline void change_to_row();
-  
   
   public:
   

--- a/inst/include/armadillo_bits/Col_meat.hpp
+++ b/inst/include/armadillo_bits/Col_meat.hpp
@@ -119,25 +119,18 @@ Col<eT>::Col(const SizeMat& s, const fill::fill_class<fill_type>& f)
 
 
 
-//! construct a column vector from specified text
 template<typename eT>
 inline
 Col<eT>::Col(const char* text)
+  : Mat<eT>(arma_vec_indicator(), 1)
   {
   arma_extra_debug_sigprint();
   
-  access::rw(Mat<eT>::vec_state) = 2;
-  
-  Mat<eT>::operator=(text);
-  
-  std::swap( access::rw(Mat<eT>::n_rows), access::rw(Mat<eT>::n_cols) );
-  
-  access::rw(Mat<eT>::vec_state) = 1;
+  (*this).operator=(text);
   }
 
 
 
-//! construct a column vector from specified text
 template<typename eT>
 inline
 Col<eT>&
@@ -145,38 +138,32 @@ Col<eT>::operator=(const char* text)
   {
   arma_extra_debug_sigprint();
   
-  access::rw(Mat<eT>::vec_state) = 2;
+  Mat<eT> tmp(text);
   
-  Mat<eT>::operator=(text);
+  arma_debug_check( ((tmp.n_elem > 0) && (tmp.is_vec() == false)), "Mat::init(): requested size is not compatible with column vector layout" );
   
-  std::swap( access::rw(Mat<eT>::n_rows), access::rw(Mat<eT>::n_cols) );
+  access::rw(tmp.n_rows) = tmp.n_elem;
+  access::rw(tmp.n_cols) = 1;
   
-  access::rw(Mat<eT>::vec_state) = 1;
+  (*this).steal_mem(tmp);
   
   return *this;
   }
 
 
 
-//! construct a column vector from specified text
 template<typename eT>
 inline
 Col<eT>::Col(const std::string& text)
+  : Mat<eT>(arma_vec_indicator(), 1)
   {
   arma_extra_debug_sigprint();
   
-  access::rw(Mat<eT>::vec_state) = 2;
-  
-  Mat<eT>::operator=(text);
-  
-  std::swap( access::rw(Mat<eT>::n_rows), access::rw(Mat<eT>::n_cols) );
-  
-  access::rw(Mat<eT>::vec_state) = 1;
+  (*this).operator=(text);
   }
 
 
 
-//! construct a column vector from specified text
 template<typename eT>
 inline
 Col<eT>&
@@ -184,13 +171,14 @@ Col<eT>::operator=(const std::string& text)
   {
   arma_extra_debug_sigprint();
   
-  access::rw(Mat<eT>::vec_state) = 2;
+  Mat<eT> tmp(text);
   
-  Mat<eT>::operator=(text);
+  arma_debug_check( ((tmp.n_elem > 0) && (tmp.is_vec() == false)), "Mat::init(): requested size is not compatible with column vector layout" );
   
-  std::swap( access::rw(Mat<eT>::n_rows), access::rw(Mat<eT>::n_cols) );
+  access::rw(tmp.n_rows) = tmp.n_elem;
+  access::rw(tmp.n_cols) = 1;
   
-  access::rw(Mat<eT>::vec_state) = 1;
+  (*this).steal_mem(tmp);
   
   return *this;
   }
@@ -238,16 +226,11 @@ Col<eT>::operator=(const std::vector<eT>& x)
   template<typename eT>
   inline
   Col<eT>::Col(const std::initializer_list<eT>& list)
+    : Mat<eT>(arma_vec_indicator(), 1)
     {
     arma_extra_debug_sigprint();
     
-    access::rw(Mat<eT>::vec_state) = 2;
-    
-    Mat<eT>::operator=(list);
-    
-    std::swap( access::rw(Mat<eT>::n_rows), access::rw(Mat<eT>::n_cols) );
-    
-    access::rw(Mat<eT>::vec_state) = 1;
+    (*this).operator=(list);
     }
   
   
@@ -259,13 +242,14 @@ Col<eT>::operator=(const std::vector<eT>& x)
     {
     arma_extra_debug_sigprint();
     
-    access::rw(Mat<eT>::vec_state) = 2;
+    Mat<eT> tmp(list);
     
-    Mat<eT>::operator=(list);
+    arma_debug_check( ((tmp.n_elem > 0) && (tmp.is_vec() == false)), "Mat::init(): requested size is not compatible with column vector layout" );
     
-    std::swap( access::rw(Mat<eT>::n_rows), access::rw(Mat<eT>::n_cols) );
+    access::rw(tmp.n_rows) = tmp.n_elem;
+    access::rw(tmp.n_cols) = 1;
     
-    access::rw(Mat<eT>::vec_state) = 1;
+    (*this).steal_mem(tmp);
     
     return *this;
     }
@@ -1088,20 +1072,6 @@ Col<eT>::end_row(const uword row_num) const
 template<typename eT>
 template<uword fixed_n_elem>
 arma_inline
-void
-Col<eT>::fixed<fixed_n_elem>::change_to_row()
-  {
-  arma_extra_debug_sigprint();
-  
-  access::rw(Mat<eT>::n_cols) = fixed_n_elem;
-  access::rw(Mat<eT>::n_rows) = 1;
-  }
-
-
-
-template<typename eT>
-template<uword fixed_n_elem>
-arma_inline
 Col<eT>::fixed<fixed_n_elem>::fixed()
   : Col<eT>( arma_fixed_indicator(), fixed_n_elem, ((use_extra) ? mem_local_extra : Mat<eT>::mem_local) )
   {
@@ -1128,7 +1098,7 @@ Col<eT>::fixed<fixed_n_elem>::fixed(const fixed<fixed_n_elem>& X)
 
 template<typename eT>
 template<uword fixed_n_elem>
-inline
+arma_inline
 Col<eT>::fixed<fixed_n_elem>::fixed(const subview_cube<eT>& X)
   : Col<eT>( arma_fixed_indicator(), fixed_n_elem, ((use_extra) ? mem_local_extra : Mat<eT>::mem_local) )
   {
@@ -1160,7 +1130,7 @@ Col<eT>::fixed<fixed_n_elem>::fixed(const fill::fill_class<fill_type>&)
 template<typename eT>
 template<uword fixed_n_elem>
 template<typename T1>
-inline
+arma_inline
 Col<eT>::fixed<fixed_n_elem>::fixed(const Base<eT,T1>& A)
   : Col<eT>( arma_fixed_indicator(), fixed_n_elem, ((use_extra) ? mem_local_extra : Mat<eT>::mem_local) )
   {
@@ -1174,7 +1144,7 @@ Col<eT>::fixed<fixed_n_elem>::fixed(const Base<eT,T1>& A)
 template<typename eT>
 template<uword fixed_n_elem>
 template<typename T1, typename T2>
-inline
+arma_inline
 Col<eT>::fixed<fixed_n_elem>::fixed(const Base<pod_type,T1>& A, const Base<pod_type,T2>& B)
   : Col<eT>( arma_fixed_indicator(), fixed_n_elem, ((use_extra) ? mem_local_extra : Mat<eT>::mem_local) )
   {
@@ -1200,9 +1170,6 @@ Col<eT>::fixed<fixed_n_elem>::fixed(const eT* aux_mem)
 
 
 
-//! NOTE: this function relies on
-//! Col::operator=(text), to change vec_state as well as swapping n_rows and n_cols,
-//! and Mat::init(), to check that the given vector will not have a different size than fixed_n_elem.
 template<typename eT>
 template<uword fixed_n_elem>
 inline
@@ -1211,16 +1178,11 @@ Col<eT>::fixed<fixed_n_elem>::fixed(const char* text)
   {
   arma_extra_debug_sigprint_this(this);
   
-  change_to_row();
-  
   Col<eT>::operator=(text);
   }
 
 
 
-//! NOTE: this function relies on
-//! Col::operator=(text), to change vec_state as well as swapping n_rows and n_cols,
-//! and Mat::init(), to check that the given vector will not have a different size than fixed_n_elem.
 template<typename eT>
 template<uword fixed_n_elem>
 inline
@@ -1228,8 +1190,6 @@ Col<eT>::fixed<fixed_n_elem>::fixed(const std::string& text)
   : Col<eT>( arma_fixed_indicator(), fixed_n_elem, ((use_extra) ? mem_local_extra : Mat<eT>::mem_local) )
   {
   arma_extra_debug_sigprint_this(this);
-  
-  change_to_row();
   
   Col<eT>::operator=(text);
   }
@@ -1272,8 +1232,6 @@ Col<eT>::fixed<fixed_n_elem>::operator=(const char* text)
   {
   arma_extra_debug_sigprint();
   
-  change_to_row();
-  
   Col<eT>::operator=(text);
   
   return *this; 
@@ -1287,8 +1245,6 @@ Col<eT>&
 Col<eT>::fixed<fixed_n_elem>::operator=(const std::string& text)
   {
   arma_extra_debug_sigprint();
-  
-  change_to_row();
   
   Col<eT>::operator=(text);
   

--- a/inst/include/armadillo_bits/Cube_bones.hpp
+++ b/inst/include/armadillo_bits/Cube_bones.hpp
@@ -315,7 +315,8 @@ class Cube : public BaseCube< eT, Cube<eT> >
   inline const Cube& randn(const uword in_rows, const uword in_cols, const uword in_slices);
   inline const Cube& randn(const SizeCube& s);
   
-  inline void reset();
+  inline void      reset();
+  inline void soft_reset();
   
   
   template<typename T1> inline void set_real(const BaseCube<pod_type,T1>& X);
@@ -333,15 +334,19 @@ class Cube : public BaseCube< eT, Cube<eT> >
   
   
   inline bool save(const std::string   name, const file_type type = arma_binary, const bool print_status = true) const;
+  inline bool save(const hdf5_name&    spec, const file_type type = hdf5_binary, const bool print_status = true) const;
   inline bool save(      std::ostream& os,   const file_type type = arma_binary, const bool print_status = true) const;
   
   inline bool load(const std::string   name, const file_type type = auto_detect, const bool print_status = true);
+  inline bool load(const hdf5_name&    spec, const file_type type = hdf5_binary, const bool print_status = true);
   inline bool load(      std::istream& is,   const file_type type = auto_detect, const bool print_status = true);
   
   inline bool quiet_save(const std::string   name, const file_type type = arma_binary) const;
+  inline bool quiet_save(const hdf5_name&    spec, const file_type type = hdf5_binary) const;
   inline bool quiet_save(      std::ostream& os,   const file_type type = arma_binary) const;
   
   inline bool quiet_load(const std::string   name, const file_type type = auto_detect);
+  inline bool quiet_load(const hdf5_name&    spec, const file_type type = hdf5_binary);
   inline bool quiet_load(      std::istream& is,   const file_type type = auto_detect);
   
   

--- a/inst/include/armadillo_bits/Cube_meat.hpp
+++ b/inst/include/armadillo_bits/Cube_meat.hpp
@@ -31,9 +31,9 @@ Cube<eT>::~Cube()
     memory::release( access::rw(mem) );
     }
   
-  if(arma_config::debug == true)
+  // try to expose buggy user code that accesses deleted objects
+  if(arma_config::debug)
     {
-    // try to expose buggy user code that accesses deleted objects
     access::rw(mem)      = 0;
     access::rw(mat_ptrs) = 0;
     }
@@ -3011,10 +3011,10 @@ Cube<eT>::impl_print(const std::string& extra_text) const
   
   if(extra_text.length() != 0)
     {
-    ARMA_DEFAULT_OSTREAM << extra_text << '\n';
+    get_cout_stream() << extra_text << '\n';
     }
   
-  arma_ostream::print(ARMA_DEFAULT_OSTREAM, *this, true);
+  arma_ostream::print(get_cout_stream(), *this, true);
   }
 
 
@@ -3052,10 +3052,10 @@ Cube<eT>::impl_raw_print(const std::string& extra_text) const
   
   if(extra_text.length() != 0)
     {
-    ARMA_DEFAULT_OSTREAM << extra_text << '\n';
+    get_cout_stream() << extra_text << '\n';
     }
   
-  arma_ostream::print(ARMA_DEFAULT_OSTREAM, *this, false);
+  arma_ostream::print(get_cout_stream(), *this, false);
   }
 
 
@@ -3516,6 +3516,26 @@ Cube<eT>::reset()
 
 
 template<typename eT>
+inline
+void
+Cube<eT>::soft_reset()
+  {
+  arma_extra_debug_sigprint();
+  
+  // don't change the size if the cube has a fixed size
+  if(mem_state <= 1)
+    {
+    reset();
+    }
+  else
+    {
+    fill(Datum<eT>::nan);
+    }
+  }
+
+
+
+template<typename eT>
 template<typename T1>
 inline
 void
@@ -3726,7 +3746,7 @@ Cube<eT>::save(const std::string name, const file_type type, const bool print_st
       break;
 
     case hdf5_binary:
-      save_okay = diskio::save_hdf5_binary(*this, name);
+      save_okay = diskio::save_hdf5_binary(*this, hdf5_name(name));
       break;
     
     case hdf5_binary_trans:
@@ -3735,7 +3755,7 @@ Cube<eT>::save(const std::string name, const file_type type, const bool print_st
       
       op_strans_cube::apply_noalias(tmp, (*this));
       
-      save_okay = diskio::save_hdf5_binary(tmp, name);
+      save_okay = diskio::save_hdf5_binary(tmp, hdf5_name(name));
       }
       break;
     
@@ -3745,6 +3765,43 @@ Cube<eT>::save(const std::string name, const file_type type, const bool print_st
     }
   
   if(print_status && (save_okay == false))  { arma_debug_warn("Cube::save(): couldn't write to ", name); }
+  
+  return save_okay;
+  }
+
+
+
+template<typename eT>
+inline
+bool
+Cube<eT>::save(const hdf5_name& spec, const file_type type, const bool print_status) const
+  {
+  arma_extra_debug_sigprint();
+  
+  bool save_okay;
+  
+  switch(type)
+    {
+    case hdf5_binary:
+      save_okay = diskio::save_hdf5_binary(*this, spec);
+      break;
+    
+    case hdf5_binary_trans:
+      {
+      Cube<eT> tmp;
+      
+      op_strans_cube::apply_noalias(tmp, (*this));
+      
+      save_okay = diskio::save_hdf5_binary(tmp, spec);
+      }
+      break;
+    
+    default:
+      if(print_status)  { arma_debug_warn("Cube::save(): unsupported file type"); }
+      save_okay = false;
+    }
+  
+  if(print_status && (save_okay == false))  { arma_debug_warn("Cube::save(): couldn't write to ", spec.filename); }
   
   return save_okay;
   }
@@ -3833,14 +3890,14 @@ Cube<eT>::load(const std::string name, const file_type type, const bool print_st
       break;
 
     case hdf5_binary:
-      load_okay = diskio::load_hdf5_binary(*this, name, err_msg);
+      load_okay = diskio::load_hdf5_binary(*this, hdf5_name(name), err_msg);
       break;
     
     case hdf5_binary_trans:
       {
       Cube<eT> tmp;
       
-      load_okay = diskio::load_hdf5_binary(tmp, name, err_msg);
+      load_okay = diskio::load_hdf5_binary(tmp, hdf5_name(name), err_msg);
       
       if(load_okay)  { op_strans_cube::apply_noalias((*this), tmp); }
       }
@@ -3865,7 +3922,60 @@ Cube<eT>::load(const std::string name, const file_type type, const bool print_st
   
   if(load_okay == false)
     {
-    (*this).reset();
+    (*this).soft_reset();
+    }
+    
+  return load_okay;
+  }
+
+
+
+template<typename eT>
+inline
+bool
+Cube<eT>::load(const hdf5_name& spec, const file_type type, const bool print_status)
+  {
+  arma_extra_debug_sigprint();
+  
+  bool load_okay;
+  std::string err_msg;
+  
+  switch(type)
+    {
+    case hdf5_binary:
+      load_okay = diskio::load_hdf5_binary(*this, spec, err_msg);
+      break;
+    
+    case hdf5_binary_trans:
+      {
+      Cube<eT> tmp;
+      
+      load_okay = diskio::load_hdf5_binary(tmp, spec, err_msg);
+      
+      if(load_okay)  { op_strans_cube::apply_noalias((*this), tmp); }
+      }
+      break;
+    
+    default:
+      if(print_status)  { arma_debug_warn("Cube::load(): unsupported file type"); }
+      load_okay = false;
+    }
+  
+  if( (print_status == true) && (load_okay == false) )
+    {
+    if(err_msg.length() > 0)
+      {
+      arma_debug_warn("Cube::load(): ", err_msg, spec.filename);
+      }
+    else
+      {
+      arma_debug_warn("Cube::load(): couldn't read ", spec.filename);
+      }
+    }
+  
+  if(load_okay == false)
+    {
+    (*this).soft_reset();
     }
     
   return load_okay;
@@ -3930,7 +4040,7 @@ Cube<eT>::load(std::istream& is, const file_type type, const bool print_status)
   
   if(load_okay == false)
     {
-    (*this).reset();
+    (*this).soft_reset();
     }
     
   return load_okay;
@@ -3947,6 +4057,18 @@ Cube<eT>::quiet_save(const std::string name, const file_type type) const
   arma_extra_debug_sigprint();
   
   return (*this).save(name, type, false);
+  }
+
+
+
+template<typename eT>
+inline
+bool
+Cube<eT>::quiet_save(const hdf5_name& spec, const file_type type) const
+  {
+  arma_extra_debug_sigprint();
+  
+  return (*this).save(spec, type, false);
   }
 
 
@@ -3973,6 +4095,18 @@ Cube<eT>::quiet_load(const std::string name, const file_type type)
   arma_extra_debug_sigprint();
   
   return (*this).load(name, type, false);
+  }
+
+
+
+template<typename eT>
+inline
+bool
+Cube<eT>::quiet_load(const hdf5_name& spec, const file_type type)
+  {
+  arma_extra_debug_sigprint();
+  
+  return (*this).load(spec, type, false);
   }
 
 

--- a/inst/include/armadillo_bits/MapMat_bones.hpp
+++ b/inst/include/armadillo_bits/MapMat_bones.hpp
@@ -1,0 +1,247 @@
+// Copyright 2008-2016 Conrad Sanderson (http://conradsanderson.id.au)
+// Copyright 2008-2016 National ICT Australia (NICTA)
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+
+//! \addtogroup MapMat
+//! @{
+
+
+
+// this class is for internal use only; subject to change and/or removal without notice
+template<typename eT>
+class MapMat
+  {
+  public:
+  
+  typedef eT                                elem_type;  //!< the type of elements stored in the matrix
+  typedef typename get_pod_type<eT>::result  pod_type;  //!< if eT is std::complex<T>, pod_type is T; otherwise pod_type is eT
+  
+  static const bool is_row = false;
+  static const bool is_col = false;
+  
+  const uword n_rows;    //!< number of rows     (read-only)
+  const uword n_cols;    //!< number of columns  (read-only)
+  const uword n_elem;    //!< number of elements (read-only)
+  
+  
+  private:
+  
+  typedef typename std::map<uword, eT> map_type;
+  
+  arma_aligned map_type* map_ptr;
+  
+  
+  public:
+  
+  inline ~MapMat();
+  inline  MapMat();
+  
+  inline explicit MapMat(const uword in_n_rows, const uword in_n_cols);
+  inline explicit MapMat(const SizeMat& s);
+  
+  inline          MapMat(const MapMat<eT>& x);
+  inline void  operator=(const MapMat<eT>& x);
+  
+  inline explicit MapMat(const SpMat<eT>& x);
+  inline void  operator=(const SpMat<eT>& x);
+  
+  #if defined(ARMA_USE_CXX11)
+  inline          MapMat(MapMat<eT>&& x);
+  inline void  operator=(MapMat<eT>&& x);
+  #endif
+  
+  inline void reset();
+  inline void set_size(const uword in_n_rows);
+  inline void set_size(const uword in_n_rows, const uword in_n_cols);
+  inline void set_size(const SizeMat& s);
+  
+  inline void zeros();
+  inline void zeros(const uword in_n_rows);
+  inline void zeros(const uword in_n_rows, const uword in_n_cols);
+  inline void zeros(const SizeMat& s);
+  
+  inline void eye();
+  inline void eye(const uword in_n_rows, const uword in_n_cols);
+  inline void eye(const SizeMat& s);
+  
+  inline void speye();
+  inline void speye(const uword in_n_rows, const uword in_n_cols);
+  inline void speye(const SizeMat& s);
+  
+  arma_inline MapMat_elem<eT> elem(const uword index,                      uword& sync_state, uword& n_nonzero);
+  arma_inline MapMat_elem<eT> elem(const uword in_row, const uword in_col, uword& sync_state, uword& n_nonzero);
+  arma_inline MapMat_svel<eT> svel(const uword in_row, const uword in_col, uword& sync_state, uword& n_nonzero, uword& sv_n_nonzero);
+  
+  arma_inline arma_warn_unused MapMat_val<eT> operator[](const uword index);
+  arma_inline arma_warn_unused            eT  operator[](const uword index) const;
+  
+  arma_inline arma_warn_unused MapMat_val<eT> operator()(const uword index);
+  arma_inline arma_warn_unused            eT  operator()(const uword index) const;
+  
+  arma_inline arma_warn_unused MapMat_val<eT>         at(const uword in_row, const uword in_col);
+  arma_inline arma_warn_unused            eT          at(const uword in_row, const uword in_col) const;
+  
+  arma_inline arma_warn_unused MapMat_val<eT> operator()(const uword in_row, const uword in_col);
+  arma_inline arma_warn_unused            eT  operator()(const uword in_row, const uword in_col) const;
+  
+  inline arma_warn_unused bool is_empty()  const;
+  inline arma_warn_unused bool is_vec()    const;
+  inline arma_warn_unused bool is_rowvec() const;
+  inline arma_warn_unused bool is_colvec() const;
+  inline arma_warn_unused bool is_square() const;
+  
+  
+  inline void sprandu(const uword in_n_rows, const uword in_n_cols, const double density);
+  
+  inline void print(const std::string& extra_text) const;
+  
+  inline uword get_n_nonzero() const;
+  inline void  get_locval_format(umat& locs, Col<eT>& vals) const;
+  
+  // for experimental purposes only
+  inline void add(const MapMat<eT>& A, const MapMat<eT>& B);
+  
+  // for experimental purposes only
+  inline void mul(const MapMat<eT>& A, const MapMat<eT>& B);
+  
+  private:
+  
+  inline void init_cold();
+  inline void init_warm(const uword in_n_rows, const uword in_n_cols);
+  
+  arma_inline void   set_val(const uword index, const eT& in_val);
+       inline void erase_val(const uword index);
+  
+  
+  friend class MapMat_val<eT>;
+  friend class MapMat_elem<eT>;
+  friend class MapMat_svel<eT>;
+  friend class SpMat<eT>;
+  };
+
+
+
+template<typename eT>
+class MapMat_val
+  {
+  private:
+  
+  arma_aligned MapMat<eT>& parent;
+  
+  arma_aligned const uword index;
+  
+  inline MapMat_val(MapMat<eT>& in_parent, const uword in_index);
+  
+  friend class MapMat<eT>;
+  
+  
+  public:
+  
+  arma_inline operator eT() const;
+  
+  arma_inline void operator= (const MapMat_val<eT>& x);
+  arma_inline void operator= (const eT in_val);
+  arma_inline void operator+=(const eT in_val);
+  arma_inline void operator-=(const eT in_val);
+  arma_inline void operator*=(const eT in_val);
+  arma_inline void operator/=(const eT in_val);
+  
+  arma_inline void operator++();
+  arma_inline void operator++(int);
+  
+  arma_inline void operator--();
+  arma_inline void operator--(int);
+  };
+
+
+
+template<typename eT>
+class MapMat_elem
+  {
+  private:
+  
+  arma_aligned MapMat<eT>& parent;
+  
+  arma_aligned const uword  index;
+  arma_aligned       uword& sync_state;
+  arma_aligned       uword& n_nonzero;
+  
+  inline MapMat_elem(MapMat<eT>& in_parent, const uword in_index, uword& in_sync_state, uword& in_n_nonzero);
+  
+  friend class MapMat<eT>;
+  
+  
+  public:
+  
+  arma_inline operator eT() const;
+  
+  arma_inline MapMat_elem<eT>& operator= (const MapMat_elem<eT>& x);
+  
+  arma_inline MapMat_elem<eT>& operator= (const eT in_val);
+  arma_inline MapMat_elem<eT>& operator+=(const eT in_val);
+  arma_inline MapMat_elem<eT>& operator-=(const eT in_val);
+  arma_inline MapMat_elem<eT>& operator*=(const eT in_val);
+  arma_inline MapMat_elem<eT>& operator/=(const eT in_val);
+  
+  arma_inline MapMat_elem<eT>& operator++();
+  arma_inline eT               operator++(int);
+  
+  arma_inline MapMat_elem<eT>& operator--();
+  arma_inline eT               operator--(int);
+  };
+
+
+
+template<typename eT>
+class MapMat_svel
+  {
+  private:
+  
+  arma_aligned MapMat<eT>& parent;
+  
+  arma_aligned const uword  index;
+  arma_aligned       uword& sync_state;
+  arma_aligned       uword& n_nonzero;
+  arma_aligned       uword& sv_n_nonzero;
+  
+  inline MapMat_svel(MapMat<eT>& in_parent, const uword in_index, uword& in_sync_state, uword& in_n_nonzero, uword& in_sv_n_nonzero);
+  
+  arma_inline void update_n_nonzeros();
+  
+  friend class MapMat<eT>;
+  
+  
+  public:
+  
+  arma_inline operator eT() const;
+  
+  arma_inline MapMat_svel<eT>& operator= (const MapMat_svel<eT>& x);
+  
+  arma_inline MapMat_svel<eT>& operator= (const eT in_val);
+  arma_inline MapMat_svel<eT>& operator+=(const eT in_val);
+  arma_inline MapMat_svel<eT>& operator-=(const eT in_val);
+  arma_inline MapMat_svel<eT>& operator*=(const eT in_val);
+  arma_inline MapMat_svel<eT>& operator/=(const eT in_val);
+  
+  arma_inline MapMat_svel<eT>& operator++();
+  arma_inline eT               operator++(int);
+  
+  arma_inline MapMat_svel<eT>& operator--();
+  arma_inline eT               operator--(int);
+  };
+
+
+
+//! @}

--- a/inst/include/armadillo_bits/MapMat_meat.hpp
+++ b/inst/include/armadillo_bits/MapMat_meat.hpp
@@ -1,0 +1,1916 @@
+// Copyright 2008-2016 Conrad Sanderson (http://conradsanderson.id.au)
+// Copyright 2008-2016 National ICT Australia (NICTA)
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+
+//! \addtogroup MapMat
+//! @{
+
+
+
+template<typename eT>
+inline
+MapMat<eT>::~MapMat()
+  {
+  arma_extra_debug_sigprint_this(this);
+  
+  reset();
+  
+  if(map_ptr)  { delete map_ptr; }
+  
+  // try to expose buggy user code that accesses deleted objects
+  if(arma_config::debug)  { map_ptr = NULL; }
+  
+  arma_type_check(( is_supported_elem_type<eT>::value == false ));
+  }
+
+
+
+template<typename eT>
+inline
+MapMat<eT>::MapMat()
+  : n_rows (0)
+  , n_cols (0)
+  , n_elem (0)
+  , map_ptr(NULL)
+  {
+  arma_extra_debug_sigprint_this(this);
+  
+  init_cold();
+  }
+
+
+
+template<typename eT>
+inline
+MapMat<eT>::MapMat(const uword in_n_rows, const uword in_n_cols)
+  : n_rows (in_n_rows)
+  , n_cols (in_n_cols)
+  , n_elem (in_n_rows * in_n_cols)
+  , map_ptr(NULL)
+  {
+  arma_extra_debug_sigprint_this(this);
+  
+  init_cold();
+  }
+
+
+
+template<typename eT>
+inline
+MapMat<eT>::MapMat(const SizeMat& s)
+  : n_rows (s.n_rows)
+  , n_cols (s.n_cols)
+  , n_elem (s.n_rows * s.n_cols)
+  , map_ptr(NULL)
+  {
+  arma_extra_debug_sigprint_this(this);
+  
+  init_cold();
+  }
+
+
+
+template<typename eT>
+inline
+MapMat<eT>::MapMat(const MapMat<eT>& x)
+  : n_rows (0)
+  , n_cols (0)
+  , n_elem (0)
+  , map_ptr(NULL)
+  {
+  arma_extra_debug_sigprint_this(this);
+  
+  init_cold();
+  
+  (*this).operator=(x);
+  }
+
+
+
+template<typename eT>
+inline
+void
+MapMat<eT>::operator=(const MapMat<eT>& x)
+  {
+  arma_extra_debug_sigprint();
+  
+  if(this == &x)  { return; }
+  
+  access::rw(n_rows) = x.n_rows;
+  access::rw(n_cols) = x.n_cols;
+  access::rw(n_elem) = x.n_elem;
+  
+  (*map_ptr) = *(x.map_ptr);
+  }
+
+
+
+template<typename eT>
+inline
+MapMat<eT>::MapMat(const SpMat<eT>& x)
+  : n_rows (0)
+  , n_cols (0)
+  , n_elem (0)
+  , map_ptr(NULL)
+  {
+  arma_extra_debug_sigprint_this(this);
+  
+  init_cold();
+  
+  (*this).operator=(x);
+  }
+
+
+
+template<typename eT>
+inline
+void
+MapMat<eT>::operator=(const SpMat<eT>& x)
+  {
+  arma_extra_debug_sigprint();
+  
+  (*this).zeros(x.n_rows, x.n_cols);
+  
+  if(x.n_nonzero == 0)  { return; }
+  
+  typename SpMat<eT>::const_iterator it     = x.begin();
+  typename SpMat<eT>::const_iterator it_end = x.end();
+  
+  map_type& map_ref = (*map_ptr);
+  
+  const uword local_n_rows = n_rows;
+  
+  for(; it != it_end; ++it)
+    {
+    const eT val = (*it);
+    
+    if(val != eT(0))
+      {
+      const uword row = it.row();
+      const uword col = it.col();
+      
+      const uword index = (local_n_rows * col) + row;
+      
+      #if defined(ARMA_USE_CXX11)
+        map_ref.emplace_hint(map_ref.cend(), index, val);
+      #else
+        map_ref.operator[](index) = val;
+      #endif
+      }
+    }
+  }
+
+
+
+#if defined(ARMA_USE_CXX11)
+
+  template<typename eT>
+  inline
+  MapMat<eT>::MapMat(MapMat<eT>&& x)
+    : n_rows (x.n_rows )
+    , n_cols (x.n_cols )
+    , n_elem (x.n_elem )
+    , map_ptr(x.map_ptr)
+    {
+    arma_extra_debug_sigprint_this(this);
+    
+    access::rw(x.n_rows)  = 0;
+    access::rw(x.n_cols)  = 0;
+    access::rw(x.n_elem)  = 0;
+    access::rw(x.map_ptr) = NULL;
+    }
+  
+  
+  
+  template<typename eT>
+  inline
+  void
+  MapMat<eT>::operator=(MapMat<eT>&& x)
+    {
+    arma_extra_debug_sigprint();
+    
+    reset();
+    
+    if(map_ptr)  { delete map_ptr; }
+    
+    access::rw(n_rows)  = x.n_rows;
+    access::rw(n_cols)  = x.n_cols;
+    access::rw(n_elem)  = x.n_elem;
+    access::rw(map_ptr) = x.map_ptr;
+    
+    access::rw(x.n_rows)  = 0;
+    access::rw(x.n_cols)  = 0;
+    access::rw(x.n_elem)  = 0;
+    access::rw(x.map_ptr) = NULL;
+    }
+
+#endif
+
+
+
+template<typename eT>
+inline
+void
+MapMat<eT>::reset()
+  {
+  arma_extra_debug_sigprint();
+  
+  init_warm(0, 0);
+  }
+
+
+
+template<typename eT>
+inline
+void
+MapMat<eT>::set_size(const uword in_n_rows)
+  {
+  arma_extra_debug_sigprint();
+  
+  init_warm(in_n_rows, 1);
+  }
+
+
+
+template<typename eT>
+inline
+void
+MapMat<eT>::set_size(const uword in_n_rows, const uword in_n_cols)
+  {
+  arma_extra_debug_sigprint();
+  
+  init_warm(in_n_rows, in_n_cols);
+  }
+
+
+
+template<typename eT>
+inline
+void
+MapMat<eT>::set_size(const SizeMat& s)
+  {
+  arma_extra_debug_sigprint();
+  
+  init_warm(s.n_rows, s.n_cols);
+  }
+
+
+
+template<typename eT>
+inline
+void
+MapMat<eT>::zeros()
+  {
+  arma_extra_debug_sigprint();
+  
+  (*map_ptr).clear();
+  }
+
+
+
+template<typename eT>
+inline
+void
+MapMat<eT>::zeros(const uword in_n_rows)
+  {
+  arma_extra_debug_sigprint();
+  
+  init_warm(in_n_rows, 1);
+  
+  (*map_ptr).clear();
+  }
+
+
+
+template<typename eT>
+inline
+void
+MapMat<eT>::zeros(const uword in_n_rows, const uword in_n_cols)
+  {
+  arma_extra_debug_sigprint();
+  
+  init_warm(in_n_rows, in_n_cols);
+  
+  (*map_ptr).clear();
+  }
+
+
+
+template<typename eT>
+inline
+void
+MapMat<eT>::zeros(const SizeMat& s)
+  {
+  arma_extra_debug_sigprint();
+  
+  init_warm(s.n_rows, s.n_cols);
+  
+  (*map_ptr).clear();
+  }
+
+
+
+template<typename eT>
+inline
+void
+MapMat<eT>::eye()
+  {
+  arma_extra_debug_sigprint();
+  
+  (*this).eye(n_rows, n_cols);
+  }
+
+
+
+template<typename eT>
+inline
+void
+MapMat<eT>::eye(const uword in_n_rows, const uword in_n_cols)
+  {
+  arma_extra_debug_sigprint();
+  
+  zeros(in_n_rows, in_n_cols);
+  
+  const uword N = (std::min)(in_n_rows, in_n_cols);
+  
+  map_type& map_ref = (*map_ptr);
+  
+  for(uword i=0; i<N; ++i)
+    {
+    const uword index = (in_n_rows * i) + i;
+    
+    #if defined(ARMA_USE_CXX11)
+      map_ref.emplace_hint(map_ref.cend(), index, eT(1));
+    #else
+      map_ref.operator[](index) = eT(1);
+    #endif
+    }
+  }
+
+
+
+template<typename eT>
+inline
+void
+MapMat<eT>::eye(const SizeMat& s)
+  {
+  arma_extra_debug_sigprint();
+  
+  (*this).eye(s.n_rows, s.n_cols);
+  }
+
+
+
+template<typename eT>
+inline
+void
+MapMat<eT>::speye()
+  {
+  arma_extra_debug_sigprint();
+  
+  (*this).eye();
+  }
+
+
+
+template<typename eT>
+inline
+void
+MapMat<eT>::speye(const uword in_n_rows, const uword in_n_cols)
+  {
+  arma_extra_debug_sigprint();
+  
+  (*this).eye(in_n_rows, in_n_cols);
+  }
+
+
+
+template<typename eT>
+inline
+void
+MapMat<eT>::speye(const SizeMat& s)
+  {
+  arma_extra_debug_sigprint();
+  
+  (*this).eye(s);
+  }
+
+
+
+template<typename eT>
+arma_inline
+MapMat_elem<eT>
+MapMat<eT>::elem(const uword index, uword& sync_state, uword& n_nonzero)
+  {
+  return MapMat_elem<eT>(*this, index, sync_state, n_nonzero);
+  }
+
+
+
+template<typename eT>
+arma_inline
+MapMat_elem<eT>
+MapMat<eT>::elem(const uword in_row, const uword in_col, uword& sync_state, uword& n_nonzero)
+  {
+  const uword index = (n_rows * in_col) + in_row;
+  
+  return MapMat_elem<eT>(*this, index, sync_state, n_nonzero);
+  }
+
+
+
+template<typename eT>
+arma_inline
+MapMat_svel<eT>
+MapMat<eT>::svel(const uword in_row, const uword in_col, uword& sync_state, uword& n_nonzero, uword& sv_n_nonzero)
+  {
+  const uword index = (n_rows * in_col) + in_row;
+  
+  return MapMat_svel<eT>(*this, index, sync_state, n_nonzero, sv_n_nonzero);
+  }
+
+
+
+template<typename eT>
+arma_inline
+arma_warn_unused
+MapMat_val<eT>
+MapMat<eT>::operator[](const uword index)
+  {
+  return MapMat_val<eT>(*this, index);
+  }
+
+
+
+template<typename eT>
+arma_inline
+arma_warn_unused
+eT
+MapMat<eT>::operator[](const uword index) const
+  {
+  map_type& map_ref = (*map_ptr);
+  
+  typename map_type::const_iterator it     = map_ref.find(index);
+  typename map_type::const_iterator it_end = map_ref.end();
+  
+  return (it != it_end) ? eT((*it).second) : eT(0);
+  }
+
+
+
+template<typename eT>
+arma_inline
+arma_warn_unused
+MapMat_val<eT>
+MapMat<eT>::operator()(const uword index)
+  {
+  arma_debug_check( (index >= n_elem), "MapMat::operator(): index out of bounds" );
+  
+  return MapMat_val<eT>(*this, index);
+  }
+
+
+
+template<typename eT>
+arma_inline
+arma_warn_unused
+eT
+MapMat<eT>::operator()(const uword index) const
+  {
+  arma_debug_check( (index >= n_elem), "MapMat::operator(): index out of bounds" );
+  
+  map_type& map_ref = (*map_ptr);
+  
+  typename map_type::const_iterator it     = map_ref.find(index);
+  typename map_type::const_iterator it_end = map_ref.end();
+  
+  return (it != it_end) ? eT((*it).second) : eT(0);
+  }
+
+
+
+template<typename eT>
+arma_inline
+arma_warn_unused
+MapMat_val<eT>
+MapMat<eT>::at(const uword in_row, const uword in_col)
+  {
+  const uword index = (n_rows * in_col) + in_row;
+  
+  return MapMat_val<eT>(*this, index);
+  }
+
+
+
+template<typename eT>
+arma_inline
+arma_warn_unused
+eT
+MapMat<eT>::at(const uword in_row, const uword in_col) const
+  {
+  const uword index = (n_rows * in_col) + in_row;
+  
+  map_type& map_ref = (*map_ptr);
+  
+  typename map_type::const_iterator it     = map_ref.find(index);
+  typename map_type::const_iterator it_end = map_ref.end();
+  
+  return (it != it_end) ? eT((*it).second) : eT(0);
+  }
+
+
+
+template<typename eT>
+arma_inline
+arma_warn_unused
+MapMat_val<eT>
+MapMat<eT>::operator()(const uword in_row, const uword in_col)
+  {
+  arma_debug_check( ((in_row >= n_rows) || (in_col >= n_cols)), "MapMat::operator(): index out of bounds" );
+  
+  const uword index = (n_rows * in_col) + in_row;
+  
+  return MapMat_val<eT>(*this, index);
+  }
+
+
+
+template<typename eT>
+arma_inline
+arma_warn_unused
+eT
+MapMat<eT>::operator()(const uword in_row, const uword in_col) const
+  {
+  arma_debug_check( ((in_row >= n_rows) || (in_col >= n_cols)), "MapMat::operator(): index out of bounds" );
+  
+  const uword index = (n_rows * in_col) + in_row;
+  
+  map_type& map_ref = (*map_ptr);
+  
+  typename map_type::const_iterator it     = map_ref.find(index);
+  typename map_type::const_iterator it_end = map_ref.end();
+  
+  return (it != it_end) ? eT((*it).second) : eT(0);
+  }
+
+
+
+template<typename eT>
+inline
+arma_warn_unused
+bool
+MapMat<eT>::is_empty() const
+  {
+  return (n_elem == 0);
+  }
+
+
+
+template<typename eT>
+inline
+arma_warn_unused
+bool
+MapMat<eT>::is_vec() const
+  {
+  return ( (n_rows == 1) || (n_cols == 1) );
+  }
+
+
+
+template<typename eT>
+inline
+arma_warn_unused
+bool
+MapMat<eT>::is_rowvec() const
+  {
+  return (n_rows == 1);
+  }
+
+
+
+//! returns true if the object can be interpreted as a column vector
+template<typename eT>
+inline
+arma_warn_unused
+bool
+MapMat<eT>::is_colvec() const
+  {
+  return (n_cols == 1);
+  }
+
+
+
+template<typename eT>
+inline
+arma_warn_unused
+bool
+MapMat<eT>::is_square() const
+  {
+  return (n_rows == n_cols);
+  }
+
+
+
+// this function is for debugging purposes only
+template<typename eT>
+inline
+void
+MapMat<eT>::sprandu(const uword in_n_rows, const uword in_n_cols, const double density)
+  {
+  arma_extra_debug_sigprint();
+  
+  zeros(in_n_rows, in_n_cols);
+  
+  const uword N = uword(density * double(n_elem));
+  
+  const Col<eT>    vals(N, fill::randu);
+  const Col<uword> indx = linspace< Col<uword> >(0, ((n_elem > 0) ? uword(n_elem-1) : uword(0)) , N);
+  
+  const eT*    vals_mem = vals.memptr();
+  const uword* indx_mem = indx.memptr();
+  
+  map_type& map_ref = (*map_ptr);
+  
+  for(uword i=0; i < N; ++i)
+    {
+    const uword index = indx_mem[i];
+    const eT    val   = vals_mem[i];
+    
+    #if defined(ARMA_USE_CXX11)
+      map_ref.emplace_hint(map_ref.cend(), index, val);
+    #else
+      map_ref.operator[](index) = val;
+    #endif
+    }
+  }
+
+
+
+// this function is for debugging purposes only
+template<typename eT>
+inline
+void
+MapMat<eT>::print(const std::string& extra_text) const
+  {
+  arma_extra_debug_sigprint();
+  
+  if(extra_text.length() != 0)
+    {
+    const std::streamsize orig_width = get_cout_stream().width();
+    
+    get_cout_stream() << extra_text << '\n';
+    
+    get_cout_stream().width(orig_width);
+    }
+  
+  map_type& map_ref = (*map_ptr);
+  
+  const uword n_nonzero = uword(map_ref.size());
+  
+  const double density = (n_elem > 0) ? ((double(n_nonzero) / double(n_elem))*double(100)) : double(0);
+  
+  get_cout_stream()
+    << "[matrix size: " << n_rows << 'x' << n_cols << "; n_nonzero: " << n_nonzero
+    << "; density: " << density << "%]\n\n";
+  
+  if(n_nonzero > 0)
+    {
+    typename map_type::const_iterator it = map_ref.begin();
+
+    for(uword i=0; i < n_nonzero; ++i)
+      {
+      const std::pair<uword, eT>& entry = (*it);
+      
+      const uword index = entry.first;
+      const eT    val   = entry.second;
+      
+      const uword row = index % n_rows;
+      const uword col = index / n_rows;
+      
+      get_cout_stream() << '(' << row << ", " << col << ") ";
+      get_cout_stream() << val << '\n';
+      
+      ++it;
+      }
+    }
+  
+  get_cout_stream().flush();
+  }
+
+
+
+template<typename eT>
+inline
+uword
+MapMat<eT>::get_n_nonzero() const
+  {
+  arma_extra_debug_sigprint();
+  
+  return uword((*map_ptr).size());
+  }
+
+
+
+template<typename eT>
+inline
+void
+MapMat<eT>::get_locval_format(umat& locs, Col<eT>& vals) const
+  {
+  arma_extra_debug_sigprint();
+  
+  map_type& map_ref = (*map_ptr);
+  
+  typename map_type::const_iterator it = map_ref.begin();
+  
+  const uword N = uword(map_ref.size());
+  
+  locs.set_size(2,N);
+  vals.set_size(N);
+  
+  eT* vals_mem = vals.memptr();
+  
+  for(uword i=0; i<N; ++i)
+    {
+    const std::pair<uword, eT>& entry = (*it);
+    
+    const uword index = entry.first;
+    const eT    val   = entry.second;
+    
+    const uword row = index % n_rows;
+    const uword col = index / n_rows;
+    
+    uword* locs_colptr = locs.colptr(i);
+    
+    locs_colptr[0] = row;
+    locs_colptr[1] = col;
+    
+    vals_mem[i] = val;
+    
+    ++it;
+    }
+  }
+
+
+
+// for experimental purposes only
+template<typename eT>
+inline
+void
+MapMat<eT>::add(const MapMat<eT>& A, const MapMat<eT>& B)
+  {
+  arma_extra_debug_sigprint();
+  
+  arma_debug_assert_same_size(A.n_rows, A.n_cols, B.n_rows, B.n_cols, "addition");
+  
+  // WARNING: potential aliasing not taken into account
+  
+  (*this).zeros(A.n_rows, A.n_cols);
+  
+  map_type& A_map_ref = *(A.map_ptr);
+  map_type& B_map_ref = *(B.map_ptr);
+  
+  typename map_type::const_iterator A_it  = A_map_ref.begin();
+  typename map_type::const_iterator A_end = A_map_ref.end();
+  
+  typename map_type::const_iterator B_it  = B_map_ref.begin();
+  typename map_type::const_iterator B_end = B_map_ref.end();
+  
+  while( (A_it != A_end) && (B_it != B_end) )
+    {
+    const std::pair<uword, eT>& A_it_deref = (*A_it);
+    const std::pair<uword, eT>& B_it_deref = (*B_it);
+    
+    const uword A_index = A_it_deref.first;
+    const uword B_index = B_it_deref.first;
+    
+    if(A_index == B_index)
+      {
+      const eT val = A_it_deref.second + B_it_deref.second;
+      
+      if(val != eT(0))  { (*this).set_val(A_index, val); }
+      
+      ++A_it;
+      ++B_it;
+      }
+    else
+      {
+      if(A_index < B_index) // if B is closer to the end
+        {
+        const eT val = A_it_deref.second;
+        
+        if(val != eT(0))  { (*this).set_val(A_index, val); }
+        
+        ++A_it;
+        }
+      else
+        {
+        const eT val = B_it_deref.second;
+        
+        if(val != eT(0))  { (*this).set_val(B_index, val); }
+        
+        ++B_it;
+        }
+      }
+    }
+  
+  while(A_it != A_end)
+    {
+    const std::pair<uword, eT>& A_it_deref = (*A_it);
+    
+    const uword index = A_it_deref.first;
+    const eT    val   = A_it_deref.second;
+    
+    if(val != eT(0))  { (*this).set_val(index, val); }
+    
+    ++A_it;
+    }
+  
+  while(B_it != B_end)
+    {
+    const std::pair<uword, eT>& B_it_deref = (*B_it);
+    
+    const uword index = B_it_deref.first;
+    const eT    val   = B_it_deref.second;
+    
+    if(val != eT(0))  { (*this).set_val(index, val); }
+    
+    ++B_it;
+    }
+  }
+
+
+
+// for experimental purposes only
+template<typename eT>
+inline
+void
+MapMat<eT>::mul(const MapMat<eT>& A, const MapMat<eT>& B)
+  {
+  arma_extra_debug_sigprint();
+  
+  const uword A_n_rows = A.n_rows;
+  const uword A_n_cols = A.n_cols;
+  
+  const uword B_n_rows = B.n_rows;
+  const uword B_n_cols = B.n_cols;
+  
+  arma_debug_assert_mul_size(A_n_rows, A_n_cols, B_n_rows, B_n_cols, "multiplication");
+  
+  // WARNING: potential aliasing not taken into account
+  
+  (*this).zeros(A_n_rows, B_n_cols);
+  
+  map_type& A_map_ref = *(A.map_ptr);
+  map_type& B_map_ref = *(B.map_ptr);
+  
+  // get transpose of A
+  
+  MapMat<eT> At(A_n_cols, A_n_rows);
+  
+  typename map_type::const_iterator A_it  = A_map_ref.begin();
+  typename map_type::const_iterator A_end = A_map_ref.end();
+  
+  for(; A_it != A_end; ++A_it)
+    {
+    const std::pair<uword, eT>& A_it_deref = (*A_it);
+    
+    const uword index = A_it_deref.first;
+    
+    const uword row = index % A_n_rows;
+    const uword col = index / A_n_rows;
+    
+    At.at(col,row) = A_it_deref.second;
+    }
+  
+  
+  // pre-calculate column iterators
+  std::vector<typename map_type::const_iterator> precalc_B_col_it (B_n_cols);
+  std::vector<typename map_type::const_iterator> precalc_B_col_end(B_n_cols);
+  
+  for(uword B_col = 0; B_col < B_n_cols; ++B_col)
+    {
+    const uword start_index = B_n_rows * B_col;
+    const uword   end_index = start_index + B_n_rows-1;
+    
+    precalc_B_col_it [B_col] = B_map_ref.lower_bound(start_index);
+    precalc_B_col_end[B_col] = B_map_ref.upper_bound(end_index);
+    }
+  
+  
+  Row<eT> tmp(A_n_cols);
+  
+  for(uword A_row = 0; A_row < A_n_rows; ++A_row)
+    {
+    const uword At_col = A_row;
+    
+    const uword At_col_start_index = At.n_rows * At_col;
+    const uword At_col_end_index   = At_col_start_index + At.n_rows-1;
+    
+    map_type& At_map_ref = *(At.map_ptr);
+    
+    typename map_type::const_iterator At_col_it  = At_map_ref.lower_bound(At_col_start_index);
+    typename map_type::const_iterator At_col_end = At_map_ref.upper_bound(At_col_end_index);
+    
+    tmp.zeros();
+    
+    // extract row
+    for(; At_col_it != At_col_end; ++At_col_it)
+      {
+      const std::pair<uword, eT>& At_col_it_deref = (*At_col_it);
+      
+      const uword index = At_col_it_deref.first - At_col_start_index;
+      
+      tmp.at(index) = At_col_it_deref.second;
+      }
+    
+    for(uword B_col = 0; B_col < B_n_cols; ++B_col)
+      {
+      const uword start_index = B_n_rows * B_col;
+      
+      typename map_type::const_iterator B_col_it  = precalc_B_col_it [B_col];
+      typename map_type::const_iterator B_col_end = precalc_B_col_end[B_col];
+      
+      eT val = eT(0);
+      
+      for(; B_col_it != B_col_end; ++B_col_it)
+        {
+        const std::pair<uword, eT>& B_col_it_deref = (*B_col_it);
+        
+        const uword index = B_col_it_deref.first - start_index;
+        
+        val += tmp.at(index) * B_col_it_deref.second;
+        }
+      
+      if(val != eT(0))  { (*this).at(A_row, B_col) = val; }
+      }
+    }
+  }
+
+
+
+template<typename eT>
+inline
+void
+MapMat<eT>::init_cold()
+  {
+  arma_extra_debug_sigprint();
+  
+  // ensure that n_elem can hold the result of (n_rows * n_cols)
+  
+  #if (defined(ARMA_USE_CXX11) || defined(ARMA_64BIT_WORD))
+    const char* error_message = "MapMat(): requested size is too large";
+  #else
+    const char* error_message = "MapMat(): requested size is too large; suggest to compile in C++11 mode or enable ARMA_64BIT_WORD";
+  #endif
+  
+  arma_debug_check
+    (
+      (
+      ( (n_rows > ARMA_MAX_UHWORD) || (n_cols > ARMA_MAX_UHWORD) )
+        ? ( (double(n_rows) * double(n_cols)) > double(ARMA_MAX_UWORD) )
+        : false
+      ),
+    error_message
+    );
+  
+  map_ptr = new (std::nothrow) map_type;
+  
+  arma_check_bad_alloc( (map_ptr == NULL), "MapMat(): out of memory" );
+  }
+
+
+
+template<typename eT>
+inline
+void
+MapMat<eT>::init_warm(const uword in_n_rows, const uword in_n_cols)
+  {
+  arma_extra_debug_sigprint();
+  
+  if( (n_rows == in_n_rows) && (n_cols == in_n_cols))  { return; }
+  
+  // ensure that n_elem can hold the result of (n_rows * n_cols)
+  
+  #if (defined(ARMA_USE_CXX11) || defined(ARMA_64BIT_WORD))
+    const char* error_message = "MapMat(): requested size is too large";
+  #else
+    const char* error_message = "MapMat(): requested size is too large; suggest to compile in C++11 mode or enable ARMA_64BIT_WORD";
+  #endif
+  
+  arma_debug_check
+    (
+      (
+      ( (in_n_rows > ARMA_MAX_UHWORD) || (in_n_cols > ARMA_MAX_UHWORD) )
+        ? ( (double(in_n_rows) * double(in_n_cols)) > double(ARMA_MAX_UWORD) )
+        : false
+      ),
+    error_message
+    );
+  
+  const uword new_n_elem = in_n_rows * in_n_cols;
+  
+  access::rw(n_rows) = in_n_rows;
+  access::rw(n_cols) = in_n_cols;
+  access::rw(n_elem) = new_n_elem;
+  
+  if( (new_n_elem == 0) && ((*map_ptr).empty() == false) )  { (*map_ptr).clear(); }
+  }
+
+
+
+template<typename eT>
+arma_inline
+void
+MapMat<eT>::set_val(const uword index, const eT& in_val)
+  {
+  arma_extra_debug_sigprint();
+  
+  if(in_val != eT(0))
+    {
+    #if defined(ARMA_USE_CXX11)
+      {
+      map_type& map_ref = (*map_ptr);
+      
+      if( (map_ref.empty() == false) && (index > uword(map_ref.crbegin()->first)) )
+        {
+        map_ref.emplace_hint(map_ref.cend(), index, in_val);
+        }
+      else
+        {
+        map_ref.operator[](index) = in_val;
+        }
+      }
+    #else
+      {
+      (*map_ptr).operator[](index) = in_val;
+      }
+    #endif
+    }
+  else
+    {
+    (*this).erase_val(index);
+    }
+  }
+
+
+
+template<typename eT>
+inline
+void
+MapMat<eT>::erase_val(const uword index)
+  {
+  arma_extra_debug_sigprint();
+  
+  map_type& map_ref = (*map_ptr);
+  
+  typename map_type::iterator it     = map_ref.find(index);
+  typename map_type::iterator it_end = map_ref.end();
+  
+  if(it != it_end)  { map_ref.erase(it); }
+  }
+
+
+
+
+
+
+// MapMat_val
+
+
+
+template<typename eT>
+arma_inline
+MapMat_val<eT>::MapMat_val(MapMat<eT>& in_parent, const uword in_index)
+  : parent(in_parent)
+  , index (in_index )
+  {
+  arma_extra_debug_sigprint();
+  }
+
+
+
+template<typename eT>
+arma_inline
+MapMat_val<eT>::operator eT() const
+  {
+  arma_extra_debug_sigprint();
+  
+  const MapMat<eT>& const_parent = parent;
+  
+  return const_parent.operator[](index);
+  }
+
+
+
+template<typename eT>
+arma_inline
+void
+MapMat_val<eT>::operator=(const MapMat_val<eT>& x)
+  {
+  arma_extra_debug_sigprint();
+  
+  const eT in_val = eT(x);
+  
+  parent.set_val(index, in_val);
+  }
+
+
+
+template<typename eT>
+arma_inline
+void
+MapMat_val<eT>::operator=(const eT in_val)
+  {
+  arma_extra_debug_sigprint();
+  
+  parent.set_val(index, in_val);
+  }
+
+
+
+template<typename eT>
+arma_inline
+void
+MapMat_val<eT>::operator+=(const eT in_val)
+  {
+  arma_extra_debug_sigprint();
+  
+  typename MapMat<eT>::map_type& map_ref = *(parent.map_ptr);
+  
+  if(in_val != eT(0))
+    {
+    eT& val = map_ref.operator[](index);  // creates the element if it doesn't exist
+    
+    val += in_val;
+    
+    if(val == eT(0))  { map_ref.erase(index); }
+    }
+  }
+
+
+
+template<typename eT>
+arma_inline
+void
+MapMat_val<eT>::operator-=(const eT in_val)
+  {
+  arma_extra_debug_sigprint();
+  
+  typename MapMat<eT>::map_type& map_ref = *(parent.map_ptr);
+  
+  if(in_val != eT(0))
+    {
+    eT& val = map_ref.operator[](index);  // creates the element if it doesn't exist
+    
+    val -= in_val;
+    
+    if(val == eT(0))  { map_ref.erase(index); }
+    }
+  }
+
+
+
+template<typename eT>
+arma_inline
+void
+MapMat_val<eT>::operator*=(const eT in_val)
+  {
+  arma_extra_debug_sigprint();
+  
+  typename MapMat<eT>::map_type& map_ref = *(parent.map_ptr);
+  
+  typename MapMat<eT>::map_type::iterator it     = map_ref.find(index);
+  typename MapMat<eT>::map_type::iterator it_end = map_ref.end();
+  
+  if(it != it_end)
+    {
+    if(in_val != eT(0))
+      {
+      eT& val = (*it).second;
+      
+      val *= in_val;
+      
+      if(val == eT(0))  { map_ref.erase(it); }
+      }
+    else
+      {
+      map_ref.erase(it);
+      }
+    }
+  }
+
+
+
+template<typename eT>
+arma_inline
+void
+MapMat_val<eT>::operator/=(const eT in_val)
+  {
+  arma_extra_debug_sigprint();
+  
+  typename MapMat<eT>::map_type& map_ref = *(parent.map_ptr);
+  
+  typename MapMat<eT>::map_type::iterator it     = map_ref.find(index);
+  typename MapMat<eT>::map_type::iterator it_end = map_ref.end();
+  
+  if(it != it_end)
+    {
+    eT& val = (*it).second;
+    
+    val /= in_val;
+    
+    if(val == eT(0))  { map_ref.erase(it); }
+    }
+  else
+    {
+    // silly operation, but included for completness
+    
+    const eT val = eT(0) / in_val;
+    
+    if(val != eT(0))  { parent.set_val(index, val); }
+    }
+  }
+
+
+
+template<typename eT>
+arma_inline
+void
+MapMat_val<eT>::operator++()
+  {
+  arma_extra_debug_sigprint();
+  
+  typename MapMat<eT>::map_type& map_ref = *(parent.map_ptr);
+  
+  eT& val = map_ref.operator[](index);  // creates the element if it doesn't exist
+  
+  val += eT(1);  // can't use ++,  as eT can be std::complex
+  
+  if(val == eT(0))  { map_ref.erase(index); }
+  }
+
+
+
+template<typename eT>
+arma_inline
+void
+MapMat_val<eT>::operator++(int)
+  {
+  arma_extra_debug_sigprint();
+  
+  (*this).operator++();
+  }
+
+
+
+template<typename eT>
+arma_inline
+void
+MapMat_val<eT>::operator--()
+  {
+  arma_extra_debug_sigprint();
+  
+  typename MapMat<eT>::map_type& map_ref = *(parent.map_ptr);
+  
+  eT& val = map_ref.operator[](index);  // creates the element if it doesn't exist
+  
+  val -= eT(1);  // can't use --,  as eT can be std::complex
+  
+  if(val == eT(0))  { map_ref.erase(index); }
+  }
+
+
+
+template<typename eT>
+arma_inline
+void
+MapMat_val<eT>::operator--(int)
+  {
+  arma_extra_debug_sigprint();
+  
+  (*this).operator--();
+  }
+
+
+
+
+
+// MapMat_elem
+
+
+
+template<typename eT>
+arma_inline
+MapMat_elem<eT>::MapMat_elem(MapMat<eT>& in_parent, const uword in_index, uword& in_sync_state, uword& in_n_nonzero)
+  : parent    (in_parent    )
+  , index     (in_index     )
+  , sync_state(in_sync_state)
+  , n_nonzero (in_n_nonzero )
+  {
+  arma_extra_debug_sigprint();
+  }
+
+
+
+template<typename eT>
+arma_inline
+MapMat_elem<eT>::operator eT() const
+  {
+  arma_extra_debug_sigprint();
+  
+  const MapMat<eT>& const_parent = parent;
+  
+  return const_parent.operator[](index);
+  }
+
+
+
+template<typename eT>
+arma_inline
+MapMat_elem<eT>&
+MapMat_elem<eT>::operator=(const MapMat_elem<eT>& x)
+  {
+  arma_extra_debug_sigprint();
+  
+  const eT in_val = eT(x);
+  
+  parent.set_val(index, in_val);
+  
+  sync_state = 1;
+  n_nonzero  = parent.get_n_nonzero();
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+arma_inline
+MapMat_elem<eT>&
+MapMat_elem<eT>::operator=(const eT in_val)
+  {
+  arma_extra_debug_sigprint();
+  
+  parent.set_val(index, in_val);
+  
+  sync_state = 1;
+  n_nonzero  = parent.get_n_nonzero();
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+arma_inline
+MapMat_elem<eT>&
+MapMat_elem<eT>::operator+=(const eT in_val)
+  {
+  arma_extra_debug_sigprint();
+  
+  typename MapMat<eT>::map_type& map_ref = *(parent.map_ptr);
+  
+  if(in_val != eT(0))
+    {
+    eT& val = map_ref.operator[](index);  // creates the element if it doesn't exist
+    
+    val += in_val;
+    
+    if(val == eT(0))  { map_ref.erase(index); }
+    
+    sync_state = 1;
+    n_nonzero  = parent.get_n_nonzero();
+    }
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+arma_inline
+MapMat_elem<eT>&
+MapMat_elem<eT>::operator-=(const eT in_val)
+  {
+  arma_extra_debug_sigprint();
+  
+  typename MapMat<eT>::map_type& map_ref = *(parent.map_ptr);
+  
+  if(in_val != eT(0))
+    {
+    eT& val = map_ref.operator[](index);  // creates the element if it doesn't exist
+    
+    val -= in_val;
+    
+    if(val == eT(0))  { map_ref.erase(index); }
+    
+    sync_state = 1;
+    n_nonzero  = parent.get_n_nonzero();
+    }
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+arma_inline
+MapMat_elem<eT>&
+MapMat_elem<eT>::operator*=(const eT in_val)
+  {
+  arma_extra_debug_sigprint();
+  
+  typename MapMat<eT>::map_type& map_ref = *(parent.map_ptr);
+  
+  typename MapMat<eT>::map_type::iterator it     = map_ref.find(index);
+  typename MapMat<eT>::map_type::iterator it_end = map_ref.end();
+  
+  if(it != it_end)
+    {
+    if(in_val != eT(0))
+      {
+      eT& val = (*it).second;
+      
+      val *= in_val;
+      
+      if(val == eT(0))  { map_ref.erase(it); }
+      }
+    else
+      {
+      map_ref.erase(it);
+      }
+    
+    sync_state = 1;
+    n_nonzero  = parent.get_n_nonzero();
+    }
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+arma_inline
+MapMat_elem<eT>&
+MapMat_elem<eT>::operator/=(const eT in_val)
+  {
+  arma_extra_debug_sigprint();
+  
+  typename MapMat<eT>::map_type& map_ref = *(parent.map_ptr);
+  
+  typename MapMat<eT>::map_type::iterator it     = map_ref.find(index);
+  typename MapMat<eT>::map_type::iterator it_end = map_ref.end();
+  
+  if(it != it_end)
+    {
+    eT& val = (*it).second;
+    
+    val /= in_val;
+    
+    if(val == eT(0))  { map_ref.erase(it); }
+    
+    sync_state = 1;
+    n_nonzero  = parent.get_n_nonzero();
+    }
+  else
+    {
+    // silly operation, but included for completness
+    
+    const eT val = eT(0) / in_val;
+    
+    if(val != eT(0))
+      {
+      parent.set_val(index, val);
+      
+      sync_state = 1;
+      n_nonzero  = parent.get_n_nonzero();
+      }
+    }
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+arma_inline
+MapMat_elem<eT>&
+MapMat_elem<eT>::operator++()
+  {
+  arma_extra_debug_sigprint();
+  
+  typename MapMat<eT>::map_type& map_ref = *(parent.map_ptr);
+  
+  eT& val = map_ref.operator[](index);  // creates the element if it doesn't exist
+  
+  val += eT(1);  // can't use ++,  as eT can be std::complex
+  
+  if(val == eT(0))  { map_ref.erase(index); }
+  
+  sync_state = 1;
+  n_nonzero  = parent.get_n_nonzero();
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+arma_inline
+eT
+MapMat_elem<eT>::operator++(int)
+  {
+  arma_extra_debug_sigprint();
+  
+  typename MapMat<eT>::map_type& map_ref = *(parent.map_ptr);
+  
+  eT& val = map_ref.operator[](index);  // creates the element if it doesn't exist
+  
+  const eT old_val = val;
+  
+  val += eT(1);  // can't use ++,  as eT can be std::complex
+  
+  if(val == eT(0))  { map_ref.erase(index); }
+  
+  sync_state = 1;
+  n_nonzero  = parent.get_n_nonzero();
+  
+  return old_val;
+  }
+
+
+
+template<typename eT>
+arma_inline
+MapMat_elem<eT>&
+MapMat_elem<eT>::operator--()
+  {
+  arma_extra_debug_sigprint();
+  
+  typename MapMat<eT>::map_type& map_ref = *(parent.map_ptr);
+  
+  eT& val = map_ref.operator[](index);  // creates the element if it doesn't exist
+  
+  val -= eT(1);  // can't use --,  as eT can be std::complex
+  
+  if(val == eT(0))  { map_ref.erase(index); }
+  
+  sync_state = 1;
+  n_nonzero  = parent.get_n_nonzero();
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+arma_inline
+eT
+MapMat_elem<eT>::operator--(int)
+  {
+  arma_extra_debug_sigprint();
+  
+  typename MapMat<eT>::map_type& map_ref = *(parent.map_ptr);
+  
+  eT& val = map_ref.operator[](index);  // creates the element if it doesn't exist
+  
+  const eT old_val = val;
+  
+  val -= eT(1);  // can't use --,  as eT can be std::complex
+  
+  if(val == eT(0))  { map_ref.erase(index); }
+  
+  sync_state = 1;
+  n_nonzero  = parent.get_n_nonzero();
+  
+  return old_val;
+  }
+
+
+
+
+
+// MapMat_svel
+
+
+
+template<typename eT>
+arma_inline
+MapMat_svel<eT>::MapMat_svel(MapMat<eT>& in_parent, const uword in_index, uword& in_sync_state, uword& in_n_nonzero, uword& in_sv_n_nonzero)
+  : parent      (in_parent      )
+  , index       (in_index       )
+  , sync_state  (in_sync_state  )
+  , n_nonzero   (in_n_nonzero   )
+  , sv_n_nonzero(in_sv_n_nonzero)
+  {
+  arma_extra_debug_sigprint();
+  }
+
+
+
+template<typename eT>
+arma_inline
+void
+MapMat_svel<eT>::update_n_nonzeros()
+  {
+  arma_extra_debug_sigprint();
+  
+  const uword old_n_nonzero = n_nonzero;
+  
+  n_nonzero = parent.get_n_nonzero();
+  
+       if(n_nonzero > old_n_nonzero)  { ++sv_n_nonzero; }
+  else if(n_nonzero < old_n_nonzero)  { --sv_n_nonzero; }
+  }
+
+
+
+template<typename eT>
+arma_inline
+MapMat_svel<eT>::operator eT() const
+  {
+  arma_extra_debug_sigprint();
+  
+  const MapMat<eT>& const_parent = parent;
+  
+  return const_parent.operator[](index);
+  }
+
+
+
+template<typename eT>
+arma_inline
+MapMat_svel<eT>&
+MapMat_svel<eT>::operator=(const MapMat_svel<eT>& x)
+  {
+  arma_extra_debug_sigprint();
+  
+  const eT in_val = eT(x);
+  
+  parent.set_val(index, in_val);
+  
+  sync_state = 1;
+  update_n_nonzeros();
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+arma_inline
+MapMat_svel<eT>&
+MapMat_svel<eT>::operator=(const eT in_val)
+  {
+  arma_extra_debug_sigprint();
+  
+  parent.set_val(index, in_val);
+  
+  sync_state = 1;
+  update_n_nonzeros();
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+arma_inline
+MapMat_svel<eT>&
+MapMat_svel<eT>::operator+=(const eT in_val)
+  {
+  arma_extra_debug_sigprint();
+  
+  typename MapMat<eT>::map_type& map_ref = *(parent.map_ptr);
+  
+  if(in_val != eT(0))
+    {
+    eT& val = map_ref.operator[](index);  // creates the element if it doesn't exist
+    
+    val += in_val;
+    
+    if(val == eT(0))  { map_ref.erase(index); }
+    
+    sync_state = 1;
+    update_n_nonzeros();
+    }
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+arma_inline
+MapMat_svel<eT>&
+MapMat_svel<eT>::operator-=(const eT in_val)
+  {
+  arma_extra_debug_sigprint();
+  
+  typename MapMat<eT>::map_type& map_ref = *(parent.map_ptr);
+  
+  if(in_val != eT(0))
+    {
+    eT& val = map_ref.operator[](index);  // creates the element if it doesn't exist
+    
+    val -= in_val;
+    
+    if(val == eT(0))  { map_ref.erase(index); }
+    
+    sync_state = 1;
+    update_n_nonzeros();
+    }
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+arma_inline
+MapMat_svel<eT>&
+MapMat_svel<eT>::operator*=(const eT in_val)
+  {
+  arma_extra_debug_sigprint();
+  
+  typename MapMat<eT>::map_type& map_ref = *(parent.map_ptr);
+  
+  typename MapMat<eT>::map_type::iterator it     = map_ref.find(index);
+  typename MapMat<eT>::map_type::iterator it_end = map_ref.end();
+  
+  if(it != it_end)
+    {
+    if(in_val != eT(0))
+      {
+      eT& val = (*it).second;
+      
+      val *= in_val;
+      
+      if(val == eT(0))  { map_ref.erase(it); }
+      }
+    else
+      {
+      map_ref.erase(it);
+      }
+    
+    sync_state = 1;
+    update_n_nonzeros();
+    }
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+arma_inline
+MapMat_svel<eT>&
+MapMat_svel<eT>::operator/=(const eT in_val)
+  {
+  arma_extra_debug_sigprint();
+  
+  typename MapMat<eT>::map_type& map_ref = *(parent.map_ptr);
+  
+  typename MapMat<eT>::map_type::iterator it     = map_ref.find(index);
+  typename MapMat<eT>::map_type::iterator it_end = map_ref.end();
+  
+  if(it != it_end)
+    {
+    eT& val = (*it).second;
+    
+    val /= in_val;
+    
+    if(val == eT(0))  { map_ref.erase(it); }
+    
+    sync_state = 1;
+    update_n_nonzeros();
+    }
+  else
+    {
+    // silly operation, but included for completness
+    
+    const eT val = eT(0) / in_val;
+    
+    if(val != eT(0))
+      {
+      parent.set_val(index, val);
+      
+      sync_state = 1;
+      update_n_nonzeros();
+      }
+    }
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+arma_inline
+MapMat_svel<eT>&
+MapMat_svel<eT>::operator++()
+  {
+  arma_extra_debug_sigprint();
+  
+  typename MapMat<eT>::map_type& map_ref = *(parent.map_ptr);
+  
+  eT& val = map_ref.operator[](index);  // creates the element if it doesn't exist
+  
+  val += eT(1);  // can't use ++,  as eT can be std::complex
+  
+  if(val == eT(0))  { map_ref.erase(index); }
+  
+  sync_state = 1;
+  update_n_nonzeros();
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+arma_inline
+eT
+MapMat_svel<eT>::operator++(int)
+  {
+  arma_extra_debug_sigprint();
+  
+  typename MapMat<eT>::map_type& map_ref = *(parent.map_ptr);
+  
+  eT& val = map_ref.operator[](index);  // creates the element if it doesn't exist
+  
+  const eT old_val = val;
+  
+  val += eT(1);  // can't use ++,  as eT can be std::complex
+  
+  if(val == eT(0))  { map_ref.erase(index); }
+  
+  sync_state = 1;
+  update_n_nonzeros();
+  
+  return old_val;
+  }
+
+
+
+template<typename eT>
+arma_inline
+MapMat_svel<eT>&
+MapMat_svel<eT>::operator--()
+  {
+  arma_extra_debug_sigprint();
+  
+  typename MapMat<eT>::map_type& map_ref = *(parent.map_ptr);
+  
+  eT& val = map_ref.operator[](index);  // creates the element if it doesn't exist
+  
+  val -= eT(1);  // can't use --,  as eT can be std::complex
+  
+  if(val == eT(0))  { map_ref.erase(index); }
+  
+  sync_state = 1;
+  update_n_nonzeros();
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+arma_inline
+eT
+MapMat_svel<eT>::operator--(int)
+  {
+  arma_extra_debug_sigprint();
+  
+  typename MapMat<eT>::map_type& map_ref = *(parent.map_ptr);
+  
+  eT& val = map_ref.operator[](index);  // creates the element if it doesn't exist
+  
+  const eT old_val = val;
+  
+  val -= eT(1);  // can't use --,  as eT can be std::complex
+  
+  if(val == eT(0))  { map_ref.erase(index); }
+  
+  sync_state = 1;
+  update_n_nonzeros();
+  
+  return old_val;
+  }
+
+
+
+//! @}

--- a/inst/include/armadillo_bits/Mat_bones.hpp
+++ b/inst/include/armadillo_bits/Mat_bones.hpp
@@ -143,14 +143,6 @@ class Mat : public Base< eT, Mat<eT> >
   inline Mat& operator%=(const diagview<eT>& X);
   inline Mat& operator/=(const diagview<eT>& X);
   
-  inline             Mat(const spdiagview<eT>& X);
-  inline Mat&  operator=(const spdiagview<eT>& X);
-  inline Mat& operator+=(const spdiagview<eT>& X);
-  inline Mat& operator-=(const spdiagview<eT>& X);
-  inline Mat& operator*=(const spdiagview<eT>& X);
-  inline Mat& operator%=(const spdiagview<eT>& X);
-  inline Mat& operator/=(const spdiagview<eT>& X);
-  
   template<typename T1> inline             Mat(const subview_elem1<eT,T1>& X);
   template<typename T1> inline Mat& operator= (const subview_elem1<eT,T1>& X);
   template<typename T1> inline Mat& operator+=(const subview_elem1<eT,T1>& X);
@@ -175,6 +167,15 @@ class Mat : public Base< eT, Mat<eT> >
   template<typename T1> inline Mat& operator*=(const SpBase<eT, T1>& m);
   template<typename T1> inline Mat& operator%=(const SpBase<eT, T1>& m);
   template<typename T1> inline Mat& operator/=(const SpBase<eT, T1>& m);
+  
+  inline explicit    Mat(const spdiagview<eT>& X);
+  inline Mat&  operator=(const spdiagview<eT>& X);
+  inline Mat& operator+=(const spdiagview<eT>& X);
+  inline Mat& operator-=(const spdiagview<eT>& X);
+  inline Mat& operator*=(const spdiagview<eT>& X);
+  inline Mat& operator%=(const spdiagview<eT>& X);
+  inline Mat& operator/=(const spdiagview<eT>& X);
+  
   
   inline mat_injector<Mat> operator<<(const eT val);
   inline mat_injector<Mat> operator<<(const injector_end_of_row<>& x);
@@ -474,7 +475,8 @@ class Mat : public Base< eT, Mat<eT> >
   inline const Mat& eye(const uword in_rows, const uword in_cols);
   inline const Mat& eye(const SizeMat& s);
   
-  inline void reset();
+  inline void      reset();
+  inline void soft_reset();
   
   
   template<typename T1> inline void set_real(const Base<pod_type,T1>& X);
@@ -492,15 +494,19 @@ class Mat : public Base< eT, Mat<eT> >
   
   
   inline bool save(const std::string   name, const file_type type = arma_binary, const bool print_status = true) const;
+  inline bool save(const hdf5_name&    spec, const file_type type = hdf5_binary, const bool print_status = true) const;
   inline bool save(      std::ostream& os,   const file_type type = arma_binary, const bool print_status = true) const;
   
   inline bool load(const std::string   name, const file_type type = auto_detect, const bool print_status = true);
+  inline bool load(const hdf5_name&    spec, const file_type type = hdf5_binary, const bool print_status = true);
   inline bool load(      std::istream& is,   const file_type type = auto_detect, const bool print_status = true);
   
   inline bool quiet_save(const std::string   name, const file_type type = arma_binary) const;
+  inline bool quiet_save(const hdf5_name&    spec, const file_type type = hdf5_binary) const;
   inline bool quiet_save(      std::ostream& os,   const file_type type = arma_binary) const;
   
   inline bool quiet_load(const std::string   name, const file_type type = auto_detect);
+  inline bool quiet_load(const hdf5_name&    spec, const file_type type = hdf5_binary);
   inline bool quiet_load(      std::istream& is,   const file_type type = auto_detect);
   
   

--- a/inst/include/armadillo_bits/Mat_meat.hpp
+++ b/inst/include/armadillo_bits/Mat_meat.hpp
@@ -29,11 +29,8 @@ Mat<eT>::~Mat()
     memory::release( access::rw(mem) );
     }
   
-  if(arma_config::debug == true)
-    {
-    // try to expose buggy user code that accesses deleted objects
-    access::rw(mem) = 0;
-    }
+  // try to expose buggy user code that accesses deleted objects
+  if(arma_config::debug)  { access::rw(mem) = 0; }
   
   arma_type_check(( is_supported_elem_type<eT>::value == false ));
   }
@@ -2279,121 +2276,6 @@ Mat<eT>::operator/=(const diagview<eT>& X)
 
 
 template<typename eT>
-inline
-Mat<eT>::Mat(const spdiagview<eT>& X)
-  : n_rows(X.n_rows)
-  , n_cols(X.n_cols)
-  , n_elem(X.n_elem)
-  , vec_state(0)
-  , mem_state(0)
-  , mem()
-  {
-  arma_extra_debug_sigprint_this(this);
-  
-  init_cold();
-  
-  spdiagview<eT>::extract(*this, X);
-  }
-
-
-
-template<typename eT>
-inline
-Mat<eT>&
-Mat<eT>::operator=(const spdiagview<eT>& X)
-  {
-  arma_extra_debug_sigprint();
-  
-  init_warm(X.n_rows, X.n_cols);
-  
-  spdiagview<eT>::extract(*this, X);
-  
-  return *this;
-  }
-
-
-
-template<typename eT>
-inline
-Mat<eT>&
-Mat<eT>::operator+=(const spdiagview<eT>& X)
-  {
-  arma_extra_debug_sigprint();
-  
-  const Mat<eT> tmp(X);
-  
-  (*this).operator+=(tmp);
-  
-  return *this;
-  }
-
-
-
-template<typename eT>
-inline
-Mat<eT>&
-Mat<eT>::operator-=(const spdiagview<eT>& X)
-  {
-  arma_extra_debug_sigprint();
-  
-  const Mat<eT> tmp(X);
-  
-  (*this).operator-=(tmp);
-  
-  return *this;
-  }
-
-
-
-template<typename eT>
-inline
-Mat<eT>&
-Mat<eT>::operator*=(const spdiagview<eT>& X)
-  {
-  arma_extra_debug_sigprint();
-  
-  const Mat<eT> tmp(X);
-  
-  (*this).operator*=(tmp);
-  
-  return *this;
-  }
-
-
-
-template<typename eT>
-inline
-Mat<eT>&
-Mat<eT>::operator%=(const spdiagview<eT>& X)
-  {
-  arma_extra_debug_sigprint();
-  
-  const Mat<eT> tmp(X);
-  
-  (*this).operator%=(tmp);
-  
-  return *this;
-  }
-
-
-
-template<typename eT>
-inline
-Mat<eT>&
-Mat<eT>::operator/=(const spdiagview<eT>& X)
-  {
-  arma_extra_debug_sigprint();
-  
-  const Mat<eT> tmp(X);
-  
-  (*this).operator/=(tmp);
-  
-  return *this;
-  }
-
-
-
-template<typename eT>
 template<typename T1>
 inline
 Mat<eT>::Mat(const subview_elem1<eT,T1>& X)
@@ -2798,6 +2680,121 @@ Mat<eT>::operator/=(const SpBase<eT, T1>& m)
     {
     at(r, c) /= p.at(r, c);
     }
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+inline
+Mat<eT>::Mat(const spdiagview<eT>& X)
+  : n_rows(X.n_rows)
+  , n_cols(X.n_cols)
+  , n_elem(X.n_elem)
+  , vec_state(0)
+  , mem_state(0)
+  , mem()
+  {
+  arma_extra_debug_sigprint_this(this);
+  
+  init_cold();
+  
+  spdiagview<eT>::extract(*this, X);
+  }
+
+
+
+template<typename eT>
+inline
+Mat<eT>&
+Mat<eT>::operator=(const spdiagview<eT>& X)
+  {
+  arma_extra_debug_sigprint();
+  
+  init_warm(X.n_rows, X.n_cols);
+  
+  spdiagview<eT>::extract(*this, X);
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+inline
+Mat<eT>&
+Mat<eT>::operator+=(const spdiagview<eT>& X)
+  {
+  arma_extra_debug_sigprint();
+  
+  const Mat<eT> tmp(X);
+  
+  (*this).operator+=(tmp);
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+inline
+Mat<eT>&
+Mat<eT>::operator-=(const spdiagview<eT>& X)
+  {
+  arma_extra_debug_sigprint();
+  
+  const Mat<eT> tmp(X);
+  
+  (*this).operator-=(tmp);
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+inline
+Mat<eT>&
+Mat<eT>::operator*=(const spdiagview<eT>& X)
+  {
+  arma_extra_debug_sigprint();
+  
+  const Mat<eT> tmp(X);
+  
+  (*this).operator*=(tmp);
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+inline
+Mat<eT>&
+Mat<eT>::operator%=(const spdiagview<eT>& X)
+  {
+  arma_extra_debug_sigprint();
+  
+  const Mat<eT> tmp(X);
+  
+  (*this).operator%=(tmp);
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+inline
+Mat<eT>&
+Mat<eT>::operator/=(const spdiagview<eT>& X)
+  {
+  arma_extra_debug_sigprint();
+  
+  const Mat<eT> tmp(X);
+  
+  (*this).operator/=(tmp);
   
   return *this;
   }
@@ -6012,14 +6009,14 @@ Mat<eT>::impl_print(const std::string& extra_text) const
   
   if(extra_text.length() != 0)
     {
-    const std::streamsize orig_width = ARMA_DEFAULT_OSTREAM.width();
+    const std::streamsize orig_width = get_cout_stream().width();
     
-    ARMA_DEFAULT_OSTREAM << extra_text << '\n';
+    get_cout_stream() << extra_text << '\n';
   
-    ARMA_DEFAULT_OSTREAM.width(orig_width);
+    get_cout_stream().width(orig_width);
     }
   
-  arma_ostream::print(ARMA_DEFAULT_OSTREAM, *this, true);
+  arma_ostream::print(get_cout_stream(), *this, true);
   }
 
 
@@ -6062,14 +6059,14 @@ Mat<eT>::impl_raw_print(const std::string& extra_text) const
   
   if(extra_text.length() != 0)
     {
-    const std::streamsize orig_width = ARMA_DEFAULT_OSTREAM.width();
+    const std::streamsize orig_width = get_cout_stream().width();
     
-    ARMA_DEFAULT_OSTREAM << extra_text << '\n';
+    get_cout_stream() << extra_text << '\n';
   
-    ARMA_DEFAULT_OSTREAM.width(orig_width);
+    get_cout_stream().width(orig_width);
     }
   
-  arma_ostream::print(ARMA_DEFAULT_OSTREAM, *this, false);
+  arma_ostream::print(get_cout_stream(), *this, false);
   }
 
 
@@ -6729,6 +6726,26 @@ Mat<eT>::reset()
 
 
 template<typename eT>
+inline
+void
+Mat<eT>::soft_reset()
+  {
+  arma_extra_debug_sigprint();
+  
+  // don't change the size if the matrix has a fixed size or is a cube slice
+  if(mem_state <= 1)
+    {
+    reset();
+    }
+  else
+    {
+    fill(Datum<eT>::nan);
+    }
+  }
+
+
+
+template<typename eT>
 template<typename T1>
 inline
 void
@@ -6931,7 +6948,7 @@ Mat<eT>::save(const std::string name, const file_type type, const bool print_sta
       break;
     
     case hdf5_binary:
-      save_okay = diskio::save_hdf5_binary(*this, name);
+      save_okay = diskio::save_hdf5_binary(*this, hdf5_name(name));
       break;
     
     case hdf5_binary_trans:
@@ -6940,7 +6957,7 @@ Mat<eT>::save(const std::string name, const file_type type, const bool print_sta
       
       op_strans::apply_mat_noalias(tmp, *this);
       
-      save_okay = diskio::save_hdf5_binary(tmp, name);
+      save_okay = diskio::save_hdf5_binary(tmp, hdf5_name(name));
       }
       break;
     
@@ -6950,6 +6967,43 @@ Mat<eT>::save(const std::string name, const file_type type, const bool print_sta
     }
   
   if(print_status && (save_okay == false))  { arma_debug_warn("Mat::save(): couldn't write to ", name); }
+  
+  return save_okay;
+  }
+
+
+
+template<typename eT>
+inline
+bool
+Mat<eT>::save(const hdf5_name& spec, const file_type type, const bool print_status) const
+  {
+  arma_extra_debug_sigprint();
+  
+  bool save_okay;
+  
+  switch(type)
+    {
+    case hdf5_binary:
+      save_okay = diskio::save_hdf5_binary(*this, spec);
+      break;
+    
+    case hdf5_binary_trans:
+      {
+      Mat<eT> tmp;
+      
+      op_strans::apply_mat_noalias(tmp, *this);
+      
+      save_okay = diskio::save_hdf5_binary(tmp, spec);
+      }
+      break;
+    
+    default:
+      if(print_status)  { arma_debug_warn("Mat::save(): unsupported file type"); }
+      save_okay = false;
+    }
+  
+  if(print_status && (save_okay == false))  { arma_debug_warn("Mat::save(): couldn't write to ", spec.filename); }
   
   return save_okay;
   }
@@ -7046,14 +7100,14 @@ Mat<eT>::load(const std::string name, const file_type type, const bool print_sta
       break;
     
     case hdf5_binary:
-      load_okay = diskio::load_hdf5_binary(*this, name, err_msg);
+      load_okay = diskio::load_hdf5_binary(*this, hdf5_name(name), err_msg);
       break;
 
     case hdf5_binary_trans:
       {
       Mat<eT> tmp;
       
-      load_okay = diskio::load_hdf5_binary(tmp, name, err_msg);
+      load_okay = diskio::load_hdf5_binary(tmp, hdf5_name(name), err_msg);
       
       if(load_okay)  { op_strans::apply_mat_noalias(*this, tmp); }
       }
@@ -7078,7 +7132,60 @@ Mat<eT>::load(const std::string name, const file_type type, const bool print_sta
   
   if(load_okay == false)
     {
-    (*this).reset();
+    (*this).soft_reset();
+    }
+    
+  return load_okay;
+  }
+
+
+
+template<typename eT>
+inline
+bool
+Mat<eT>::load(const hdf5_name& spec, const file_type type, const bool print_status)
+  {
+  arma_extra_debug_sigprint();
+  
+  bool load_okay;
+  std::string err_msg;
+  
+  switch(type)
+    {
+    case hdf5_binary:
+      load_okay = diskio::load_hdf5_binary(*this, spec, err_msg);
+      break;
+
+    case hdf5_binary_trans:
+      {
+      Mat<eT> tmp;
+      
+      load_okay = diskio::load_hdf5_binary(tmp, spec, err_msg);
+      
+      if(load_okay)  { op_strans::apply_mat_noalias(*this, tmp); }
+      }
+      break;
+
+    default:
+      if(print_status)  { arma_debug_warn("Mat::load(): unsupported file type"); }
+      load_okay = false;
+    }
+  
+  if( (print_status == true) && (load_okay == false) )
+    {
+    if(err_msg.length() > 0)
+      {
+      arma_debug_warn("Mat::load(): ", err_msg, spec.filename);
+      }
+    else
+      {
+      arma_debug_warn("Mat::load(): couldn't read ", spec.filename);
+      }
+    }
+  
+  if(load_okay == false)
+    {
+    (*this).soft_reset();
     }
     
   return load_okay;
@@ -7147,7 +7254,7 @@ Mat<eT>::load(std::istream& is, const file_type type, const bool print_status)
   
   if(load_okay == false)
     {
-    (*this).reset();
+    (*this).soft_reset();
     }
     
   return load_okay;
@@ -7164,6 +7271,18 @@ Mat<eT>::quiet_save(const std::string name, const file_type type) const
   arma_extra_debug_sigprint();
   
   return (*this).save(name, type, false);
+  }
+
+
+
+template<typename eT>
+inline
+bool
+Mat<eT>::quiet_save(const hdf5_name& spec, const file_type type) const
+  {
+  arma_extra_debug_sigprint();
+  
+  return (*this).save(spec, type, false);
   }
 
 
@@ -7190,6 +7309,18 @@ Mat<eT>::quiet_load(const std::string name, const file_type type)
   arma_extra_debug_sigprint();
   
   return (*this).load(name, type, false);
+  }
+
+
+
+template<typename eT>
+inline
+bool
+Mat<eT>::quiet_load(const hdf5_name& spec, const file_type type)
+  {
+  arma_extra_debug_sigprint();
+  
+  return (*this).load(spec, type, false);
   }
 
 

--- a/inst/include/armadillo_bits/Proxy.hpp
+++ b/inst/include/armadillo_bits/Proxy.hpp
@@ -943,52 +943,6 @@ class Proxy< diagview<eT> >
 
 
 
-template<typename eT>
-class Proxy< spdiagview<eT> >
-  {
-  public:
-  
-  typedef eT                                       elem_type;
-  typedef typename get_pod_type<elem_type>::result pod_type;
-  typedef spdiagview<eT>                           stored_type;
-  typedef const spdiagview<eT>&                    ea_type;
-  typedef const spdiagview<eT>&                    aligned_ea_type;
-  
-  static const bool use_at      = false;
-  static const bool use_mp      = false;
-  static const bool has_subview = false;
-  static const bool fake_mat    = false;
-  
-  static const bool is_row = false;
-  static const bool is_col = true;
-  
-  arma_aligned const spdiagview<eT>& Q;
-  
-  inline explicit Proxy(const spdiagview<eT>& A)
-    : Q(A)
-    {
-    arma_extra_debug_sigprint();
-    }
-  
-  arma_inline uword get_n_rows() const { return Q.n_rows; }
-  arma_inline uword get_n_cols() const { return 1;        }
-  arma_inline uword get_n_elem() const { return Q.n_elem; }
-  
-  arma_inline elem_type operator[] (const uword i)                const { return Q[i];         }
-  arma_inline elem_type at         (const uword row, const uword) const { return Q.at(row, 0); }
-  arma_inline elem_type at_alt     (const uword i)                const { return Q[i];         }
-  
-  arma_inline         ea_type         get_ea() const { return Q; }
-  arma_inline aligned_ea_type get_aligned_ea() const { return Q; }
-  
-  template<typename eT2>
-  arma_inline bool is_alias(const Mat<eT2>&) const { return false; }
-  
-  arma_inline bool is_aligned() const { return false; }
-  };
-
-
-
 template<typename T1>
 class Proxy_diagvec_mat
   {

--- a/inst/include/armadillo_bits/Row_meat.hpp
+++ b/inst/include/armadillo_bits/Row_meat.hpp
@@ -55,7 +55,7 @@ Row<eT>::Row(const uword in_n_elem)
 template<typename eT>
 inline
 Row<eT>::Row(const uword in_n_rows, const uword in_n_cols)
-  : Mat<eT>(arma_vec_indicator(), 2)
+  : Mat<eT>(arma_vec_indicator(), 0, 0, 2)
   {
   arma_extra_debug_sigprint();
   
@@ -67,7 +67,7 @@ Row<eT>::Row(const uword in_n_rows, const uword in_n_cols)
 template<typename eT>
 inline
 Row<eT>::Row(const SizeMat& s)
-  : Mat<eT>(arma_vec_indicator(), 2)
+  : Mat<eT>(arma_vec_indicator(), 0, 0, 2)
   {
   arma_extra_debug_sigprint();
   
@@ -93,7 +93,7 @@ template<typename eT>
 template<typename fill_type>
 inline
 Row<eT>::Row(const uword in_n_rows, const uword in_n_cols, const fill::fill_class<fill_type>& f)
-  : Mat<eT>(arma_vec_indicator(), 2)
+  : Mat<eT>(arma_vec_indicator(), 0, 0, 2)
   {
   arma_extra_debug_sigprint();
   
@@ -108,7 +108,7 @@ template<typename eT>
 template<typename fill_type>
 inline
 Row<eT>::Row(const SizeMat& s, const fill::fill_class<fill_type>& f)
-  : Mat<eT>(arma_vec_indicator(), 2)
+  : Mat<eT>(arma_vec_indicator(), 0, 0, 2)
   {
   arma_extra_debug_sigprint();
   
@@ -122,12 +122,11 @@ Row<eT>::Row(const SizeMat& s, const fill::fill_class<fill_type>& f)
 template<typename eT>
 inline
 Row<eT>::Row(const char* text)
+  : Mat<eT>(arma_vec_indicator(), 2)
   {
   arma_extra_debug_sigprint();
   
-  access::rw(Mat<eT>::vec_state) = 2;
-  
-  Mat<eT>::operator=(text);
+  (*this).operator=(text);
   }
   
 
@@ -139,7 +138,14 @@ Row<eT>::operator=(const char* text)
   {
   arma_extra_debug_sigprint();
   
-  Mat<eT>::operator=(text);
+  Mat<eT> tmp(text);
+  
+  arma_debug_check( ((tmp.n_elem > 0) && (tmp.is_vec() == false)), "Mat::init(): requested size is not compatible with row vector layout" );
+  
+  access::rw(tmp.n_rows) = 1;
+  access::rw(tmp.n_cols) = tmp.n_elem;
+  
+  (*this).steal_mem(tmp);
   
   return *this;
   }
@@ -149,12 +155,11 @@ Row<eT>::operator=(const char* text)
 template<typename eT>
 inline
 Row<eT>::Row(const std::string& text)
+  : Mat<eT>(arma_vec_indicator(), 2)
   {
   arma_extra_debug_sigprint();
   
-  access::rw(Mat<eT>::vec_state) = 2;
-  
-  Mat<eT>::operator=(text);
+  (*this).operator=(text);
   }
 
 
@@ -166,7 +171,14 @@ Row<eT>::operator=(const std::string& text)
   {
   arma_extra_debug_sigprint();
   
-  Mat<eT>::operator=(text);
+  Mat<eT> tmp(text);
+  
+  arma_debug_check( ((tmp.n_elem > 0) && (tmp.is_vec() == false)), "Mat::init(): requested size is not compatible with row vector layout" );
+  
+  access::rw(tmp.n_rows) = 1;
+  access::rw(tmp.n_cols) = tmp.n_elem;
+  
+  (*this).steal_mem(tmp);
   
   return *this;
   }
@@ -214,12 +226,11 @@ Row<eT>::operator=(const std::vector<eT>& x)
   template<typename eT>
   inline
   Row<eT>::Row(const std::initializer_list<eT>& list)
+    : Mat<eT>(arma_vec_indicator(), 2)
     {
     arma_extra_debug_sigprint();
     
-    access::rw(Mat<eT>::vec_state) = 2;
-    
-    Mat<eT>::operator=(list);
+    (*this).operator=(list);
     }
   
   
@@ -231,7 +242,14 @@ Row<eT>::operator=(const std::vector<eT>& x)
     {
     arma_extra_debug_sigprint();
     
-    Mat<eT>::operator=(list);
+    Mat<eT> tmp(list);
+    
+    arma_debug_check( ((tmp.n_elem > 0) && (tmp.is_vec() == false)), "Mat::init(): requested size is not compatible with row vector layout" );
+    
+    access::rw(tmp.n_rows) = 1;
+    access::rw(tmp.n_cols) = tmp.n_elem;
+    
+    (*this).steal_mem(tmp);
     
     return *this;
     }
@@ -1053,7 +1071,7 @@ Row<eT>::end_row(const uword row_num) const
 
 template<typename eT>
 template<uword fixed_n_elem>
-inline
+arma_inline
 Row<eT>::fixed<fixed_n_elem>::fixed()
   : Row<eT>( arma_fixed_indicator(), fixed_n_elem, ((use_extra) ? mem_local_extra : Mat<eT>::mem_local) )
   {

--- a/inst/include/armadillo_bits/SpCol_meat.hpp
+++ b/inst/include/armadillo_bits/SpCol_meat.hpp
@@ -243,6 +243,8 @@ SpCol<eT>::shed_rows(const uword in_row1, const uword in_row2)
     "SpCol::shed_rows(): indices out of bounds or incorrectly used"
     );
   
+  SpMat<eT>::sync_csc();
+  
   const uword diff = (in_row2 - in_row1 + 1);
 
   // This is easy because everything is in one column.
@@ -306,6 +308,8 @@ SpCol<eT>::shed_rows(const uword in_row1, const uword in_row2)
 
   access::rw(SpMat<eT>::n_rows) -= diff;
   access::rw(SpMat<eT>::n_elem) -= diff;
+  
+  SpMat<eT>::invalidate_cache();
   }
 
 
@@ -346,6 +350,8 @@ SpCol<eT>::begin_row(const uword row_num)
   
   arma_debug_check( (row_num >= SpMat<eT>::n_rows), "SpCol::begin_row(): index out of bounds");
   
+  SpMat<eT>::sync_csc();
+  
   return row_iterator(*this, row_num, 0);
   }
 
@@ -359,6 +365,8 @@ SpCol<eT>::begin_row(const uword row_num) const
   arma_extra_debug_sigprint();
   
   arma_debug_check( (row_num >= SpMat<eT>::n_rows), "SpCol::begin_row(): index out of bounds");
+  
+  SpMat<eT>::sync_csc();
   
   return const_row_iterator(*this, row_num, 0);
   }
@@ -374,6 +382,8 @@ SpCol<eT>::end_row(const uword row_num)
   
   arma_debug_check( (row_num >= SpMat<eT>::n_rows), "SpCol::end_row(): index out of bounds");
   
+  SpMat<eT>::sync_csc();
+  
   return row_iterator(*this, row_num + 1, 0);
   }
 
@@ -387,6 +397,8 @@ SpCol<eT>::end_row(const uword row_num) const
   arma_extra_debug_sigprint();
   
   arma_debug_check( (row_num >= SpMat<eT>::n_rows), "SpCol::end_row(): index out of bounds");
+  
+  SpMat<eT>::sync_csc();
   
   return const_row_iterator(*this, row_num + 1, 0);
   }

--- a/inst/include/armadillo_bits/SpMat_bones.hpp
+++ b/inst/include/armadillo_bits/SpMat_bones.hpp
@@ -36,47 +36,47 @@ class SpMat : public SpBase< eT, SpMat<eT> >
   const uword n_nonzero; //!< number of nonzero elements (read-only)
   const uword vec_state; //!< 0: matrix; 1: column vector; 2: row vector
   
-  // so that SpValProxy can call add_element() and delete_element()
-  friend class SpValProxy<SpMat<eT> >;
-  friend class SpSubview<eT>;
   
-  /**
-   * The memory used to store the values of the matrix.
-   * In accordance with the CSC format, this stores only the actual values.
-   * The correct locations of the values are assembled from the row indices
-   * and the column pointers.
-   * 
-   * The length of this array is (n_nonzero + 1); the final value ensures
-   * the integrity of iterators.  If you are planning on resizing this vector,
-   * it's probably best to use mem_resize() instead, which automatically sets
-   * the length to (n_nonzero + 1).  If you need to allocate the memory yourself
-   * for some reason, be sure to set values[n_nonzero] to 0.
-   */
+  // The memory used to store the values of the matrix.
+  // In accordance with the CSC format, this stores only the actual values.
+  // The correct locations of the values are assembled from the row indices and column pointers.
+  // 
+  // The length of this array is (n_nonzero + 1).
+  // The final value values[n_nonzero] must be zero to ensure integrity of iterators.
+  // Use mem_resize(new_n_nonzero) to resize this array.
+  // 
+  // WARNING: the 'values' array is only valid after sync() is called;
+  // WARNING: there is a separate cache for fast element insertion
+  
   arma_aligned const eT* const values;
   
-  /**
-   * The row indices of each value.  row_indices[i] is the row of values[i].
-   * 
-   * The length of this array is (n_nonzero + 1); the final value ensures
-   * the integrity of iterators.  If you are planning on resizing this vector,
-   * it's probably best to use mem_resize() instead.  If you need to allocate
-   * the memory yourself for some reason, be sure to set row_indices[n_nonzero] to 0.
-   */
+  
+  // The row indices of each value.  row_indices[i] is the row of values[i].
+  // 
+  // The length of this array is (n_nonzero + 1).
+  // The final value row_indices[n_nonzero] must be zero to ensure integrity of iterators.
+  // Use mem_resize(new_n_nonzero) to resize this array.
+  // 
+  // WARNING: the 'row_indices' array is only valid after sync() is called;
+  // WARNING: there is a separate cache for fast element insertion
+  
   arma_aligned const uword* const row_indices;
   
-  /**
-   * The column pointers.  This stores the index of the first item in column i.
-   * That is, values[col_ptrs[i]] is the first value in column i, and it is in
-   * the row indicated by row_indices[col_ptrs[i]].
-   * 
-   * This array is of length (n_cols + 2); the element col_ptrs[n_cols] should
-   * be equal to n_nonzero, and the element col_ptrs[n_cols + 1] is an invalid
-   * very large value that ensures the integrity of iterators.
-   * 
-   * The col_ptrs array is set by the init() function (which is called by the
-   * constructors and set_size() and other functions that set the size of the
-   * matrix), so allocating col_ptrs by hand should not be necessary.
-   */
+  
+  // The column pointers.  This stores the index of the first item in column i.
+  // That is, values[col_ptrs[i]] is the first value in column i,
+  // and it is in the row indicated by row_indices[col_ptrs[i]].
+  // 
+  // The length of this array is (n_cols + 2).
+  // The element col_ptrs[n_cols] must be equal to n_nonzero.
+  // The element col_ptrs[n_cols + 1] must be an invalid very large value to ensure integrity of iterators.
+  // 
+  // The col_ptrs array is set by the init() function
+  // (which is called by constructors, set_size() and other functions that change the matrix size).
+  // 
+  // WARNING: the 'col_ptrs' array is only valid after sync() is called;
+  // WARNING: there is a separate cache for fast element insertion
+  
   arma_aligned const uword* const col_ptrs;
   
   inline  SpMat();
@@ -91,11 +91,13 @@ class SpMat : public SpBase< eT, SpMat<eT> >
   inline SpMat& operator=(const std::string& text);
   inline            SpMat(const SpMat<eT>&   x);
   
-  
   #if defined(ARMA_USE_CXX11)
   inline            SpMat(SpMat&& m);
   inline SpMat& operator=(SpMat&& m);
   #endif
+  
+  inline explicit    SpMat(const MapMat<eT>& x);
+  inline SpMat&  operator=(const MapMat<eT>& x);
   
   template<typename T1, typename T2, typename T3>
   inline SpMat(const Base<uword,T1>& rowind, const Base<uword,T2>& colptr, const Base<eT,T3>& values, const uword n_rows, const uword n_cols);
@@ -141,6 +143,14 @@ class SpMat : public SpBase< eT, SpMat<eT> >
   inline SpMat& operator*=(const SpSubview<eT>& X);
   inline SpMat& operator%=(const SpSubview<eT>& X);
   inline SpMat& operator/=(const SpSubview<eT>& X);
+  
+  inline             SpMat(const spdiagview<eT>& X);
+  inline SpMat&  operator=(const spdiagview<eT>& X);
+  inline SpMat& operator+=(const spdiagview<eT>& X);
+  inline SpMat& operator-=(const spdiagview<eT>& X);
+  inline SpMat& operator*=(const spdiagview<eT>& X);
+  inline SpMat& operator%=(const spdiagview<eT>& X);
+  inline SpMat& operator/=(const spdiagview<eT>& X);
   
   // delayed unary ops
   template<typename T1, typename spop_type> inline             SpMat(const SpOp<T1, spop_type>& X);
@@ -232,18 +242,18 @@ class SpMat : public SpBase< eT, SpMat<eT> >
   
   
   // access the i-th element; if there is nothing at element i, 0 is returned
-  arma_inline arma_warn_unused SpValProxy<SpMat<eT> > operator[] (const uword i);
-  arma_inline arma_warn_unused eT                     operator[] (const uword i) const;
-  arma_inline arma_warn_unused SpValProxy<SpMat<eT> > at         (const uword i);
-  arma_inline arma_warn_unused eT                     at         (const uword i) const;
-  arma_inline arma_warn_unused SpValProxy<SpMat<eT> > operator() (const uword i);
-  arma_inline arma_warn_unused eT                     operator() (const uword i) const;
+  arma_inline arma_warn_unused MapMat_elem<eT> operator[] (const uword i);
+  arma_inline arma_warn_unused eT              operator[] (const uword i) const;
+  arma_inline arma_warn_unused MapMat_elem<eT> at         (const uword i);
+  arma_inline arma_warn_unused eT              at         (const uword i) const;
+  arma_inline arma_warn_unused MapMat_elem<eT> operator() (const uword i);
+  arma_inline arma_warn_unused eT              operator() (const uword i) const;
   
   // access the element at the given row and column; if there is nothing at that position, 0 is returned
-  arma_inline arma_warn_unused SpValProxy<SpMat<eT> > at         (const uword in_row, const uword in_col);
-  arma_inline arma_warn_unused eT                     at         (const uword in_row, const uword in_col) const;
-  arma_inline arma_warn_unused SpValProxy<SpMat<eT> > operator() (const uword in_row, const uword in_col);
-  arma_inline arma_warn_unused eT                     operator() (const uword in_row, const uword in_col) const;
+  arma_inline arma_warn_unused MapMat_elem<eT> at         (const uword in_row, const uword in_col);
+  arma_inline arma_warn_unused eT              at         (const uword in_row, const uword in_col) const;
+  arma_inline arma_warn_unused MapMat_elem<eT> operator() (const uword in_row, const uword in_col);
+  arma_inline arma_warn_unused eT              operator() (const uword in_row, const uword in_col) const;
   
   
   arma_inline arma_warn_unused bool is_empty()  const;
@@ -323,6 +333,7 @@ class SpMat : public SpBase< eT, SpMat<eT> >
   
   
   // saving and loading
+  // TODO: implement auto_detect for sparse matrices
   
   inline bool save(const std::string   name, const file_type type = arma_binary, const bool print_status = true) const;
   inline bool save(      std::ostream& os,   const file_type type = arma_binary, const bool print_status = true) const;
@@ -336,9 +347,6 @@ class SpMat : public SpBase< eT, SpMat<eT> >
   inline bool quiet_load(const std::string   name, const file_type type = arma_binary);
   inline bool quiet_load(      std::istream& is,   const file_type type = arma_binary);
   
-  // TODO: speed up loading of sparse matrices stored as text files (ie. raw_ascii and coord_ascii)
-  // TODO: implement auto_detect for sparse matrices
-  // TODO: modify docs to specify which formats are not applicable to sparse matrices
   
   
   // necessary forward declarations
@@ -357,7 +365,7 @@ class SpMat : public SpBase< eT, SpMat<eT> >
     inline iterator_base(const SpMat& in_M);
     inline iterator_base(const SpMat& in_M, const uword col, const uword pos);
     
-    inline arma_hot eT operator*() const;
+    arma_inline eT operator*() const;
     
     // don't hold location internally; call "dummy" methods to get that information
     arma_inline uword row() const { return M->row_indices[internal_pos]; }
@@ -535,19 +543,23 @@ class SpMat : public SpBase< eT, SpMat<eT> >
   inline bool  empty() const;
   inline uword size()  const;
   
-  /**
-   * Resize memory.
-   * You are responsible for updating the column pointers and filling the new memory (if the new size is larger).
-   * If the new size is smaller, the first new_n_nonzero elements will be copied.
-   * n_nonzero is updated.
-   */
+  // Resize memory.
+  // If the new size is larger, the column pointers and new memory still need to be correctly set.
+  // If the new size is smaller, the first new_n_nonzero elements will be copied.
+  // n_nonzero is updated.
   inline void mem_resize(const uword new_n_nonzero);
+  
+  //! synchronise CSC from cache
+  inline void sync() const;
   
   //! don't use this unless you're writing internal Armadillo code
   inline void remove_zeros();
   
   //! don't use this unless you're writing internal Armadillo code
   inline void steal_mem(SpMat& X);
+  
+  //! don't use this unless you're writing internal Armadillo code
+  inline void steal_mem_simple(SpMat& X);
   
   //! don't use this unless you're writing internal Armadillo code
   template<              typename T1, typename Functor> arma_hot inline void init_xform   (const SpBase<eT, T1>& x, const Functor& func);
@@ -558,7 +570,8 @@ class SpMat : public SpBase< eT, SpMat<eT> >
   
   inline void init(uword in_rows, uword in_cols);
   inline void init(const std::string& text);
-  inline void init(const SpMat& x);
+  inline void init(const  SpMat<eT>& x);
+  inline void init(const MapMat<eT>& x);
   
   
   inline void init_batch_std(const Mat<uword>& locations, const Mat<eT>& values, const bool sort_locations);
@@ -586,6 +599,27 @@ class SpMat : public SpBase< eT, SpMat<eT> >
   inline arma_hot arma_warn_unused eT& add_element(const uword in_row, const uword in_col, const eT in_val = eT(0));
   
   inline arma_hot void delete_element(const uword in_row, const uword in_col);
+  
+  
+  // cache related
+  
+  arma_aligned mutable MapMat<eT> cache;
+  arma_aligned mutable uword      sync_state;
+  // 0: cache needs to be updated from CSC
+  // 1: CSC needs to be updated from cache
+  // 2: no update required
+  
+  arma_inline void invalidate_cache() const;
+  arma_inline void invalidate_csc()   const;
+  
+  arma_inline void sync_cache() const;
+  arma_inline void sync_csc()   const;
+  
+  
+  friend class SpValProxy< SpMat<eT> >;  // so that SpValProxy can call add_element() and delete_element()
+  friend class SpSubview<eT>;
+  friend class SpRow<eT>;
+  friend class SpCol<eT>;
   
   
   public:

--- a/inst/include/armadillo_bits/SpMat_iterators_meat.hpp
+++ b/inst/include/armadillo_bits/SpMat_iterators_meat.hpp
@@ -60,8 +60,7 @@ SpMat<eT>::iterator_base::iterator_base(const SpMat<eT>& in_M, const uword in_co
 
 
 template<typename eT>
-inline
-arma_hot
+arma_inline
 eT
 SpMat<eT>::iterator_base::operator*() const
   {

--- a/inst/include/armadillo_bits/SpMat_meat.hpp
+++ b/inst/include/armadillo_bits/SpMat_meat.hpp
@@ -35,6 +35,8 @@ SpMat<eT>::SpMat()
   {
   arma_extra_debug_sigprint_this(this);
   
+  invalidate_cache();
+  
   access::rw(values[0]) = 0;
   access::rw(row_indices[0]) = 0;
   
@@ -224,6 +226,39 @@ SpMat<eT>::SpMat(const SpMat<eT>& x)
     }
   
 #endif
+
+
+
+template<typename eT>
+inline
+SpMat<eT>::SpMat(const MapMat<eT>& x)
+  : n_rows(0)
+  , n_cols(0)
+  , n_elem(0)
+  , n_nonzero(0)
+  , vec_state(0)
+  , values(NULL)
+  , row_indices(NULL)
+  , col_ptrs(NULL)
+  {
+  arma_extra_debug_sigprint_this(this);
+  
+  init(x);
+  }
+
+
+
+template<typename eT>
+inline
+SpMat<eT>&
+SpMat<eT>::operator=(const MapMat<eT>& x)
+  {
+  arma_extra_debug_sigprint();
+  
+  init(x);
+  
+  return *this;
+  }
 
 
 
@@ -549,9 +584,25 @@ SpMat<eT>::operator*=(const eT val)
   
   if(val != eT(0))
     {
-    arrayops::inplace_mul( access::rwp(values), val, n_nonzero );
+    sync_csc();
+    invalidate_cache();
     
-    remove_zeros();
+    const uword n_nz = n_nonzero;
+    
+    eT* vals = access::rwp(values);
+    
+    bool has_zero = false;
+    
+    for(uword i=0; i<n_nz; ++i)
+      {
+      eT& vals_i = vals[i];
+      
+      vals_i *= val;
+      
+      if(vals_i == eT(0))  { has_zero = true; }
+      }
+    
+    if(has_zero)  { remove_zeros(); }
     }
   else
     {
@@ -573,9 +624,25 @@ SpMat<eT>::operator/=(const eT val)
   
   arma_debug_check( (val == eT(0)), "element-wise division: division by zero" );
   
-  arrayops::inplace_div( access::rwp(values), val, n_nonzero );
+  sync_csc();
+  invalidate_cache();
   
-  remove_zeros();
+  const uword n_nz = n_nonzero;
+  
+  eT* vals = access::rwp(values);
+  
+  bool has_zero = false;
+  
+  for(uword i=0; i<n_nz; ++i)
+    {
+    eT& vals_i = vals[i];
+    
+    vals_i /= val;
+    
+    if(vals_i == eT(0))  { has_zero = true; }
+    }
+  
+  if(has_zero)  { remove_zeros(); }
   
   return *this;
   }
@@ -603,6 +670,8 @@ SpMat<eT>::operator+=(const SpMat<eT>& x)
   {
   arma_extra_debug_sigprint();
   
+  sync_csc();
+  
   SpMat<eT> out = (*this) + x;
   
   steal_mem(out);
@@ -619,6 +688,8 @@ SpMat<eT>::operator-=(const SpMat<eT>& x)
   {
   arma_extra_debug_sigprint();
   
+  sync_csc();
+  
   SpMat<eT> out = (*this) - x;
   
   steal_mem(out);
@@ -634,6 +705,8 @@ SpMat<eT>&
 SpMat<eT>::operator*=(const SpMat<eT>& y)
   {
   arma_extra_debug_sigprint();
+  
+  sync_csc();
   
   SpMat<eT> z = (*this) * y;
   
@@ -652,9 +725,35 @@ SpMat<eT>::operator%=(const SpMat<eT>& y)
   {
   arma_extra_debug_sigprint();
   
+  sync_csc();
+  
   SpMat<eT> z = (*this) % y;
   
   steal_mem(z);
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+inline
+SpMat<eT>&
+SpMat<eT>::operator/=(const SpMat<eT>& x)
+  {
+  arma_extra_debug_sigprint();
+  
+  arma_debug_assert_same_size(n_rows, n_cols, x.n_rows, x.n_cols, "element-wise division");
+  
+  // If you use this method, you are probably stupid or misguided,
+  // but for compatibility with Mat, we have implemented it anyway.
+  for(uword c = 0; c < n_cols; ++c)
+    {
+    for(uword r = 0; r < n_rows; ++r)
+      {
+      at(r, c) /= x.at(r, c);
+      }
+    }
   
   return *this;
   }
@@ -759,30 +858,6 @@ SpMat<eT>::SpMat
 
 
 template<typename eT>
-inline
-SpMat<eT>&
-SpMat<eT>::operator/=(const SpMat<eT>& x)
-  {
-  arma_extra_debug_sigprint();
-  
-  arma_debug_assert_same_size(n_rows, n_cols, x.n_rows, x.n_cols, "element-wise division");
-  
-  // If you use this method, you are probably stupid or misguided, but for compatibility with Mat, we have implemented it anyway.
-  // We have to loop over every element, which is not good.  In fact, it makes me physically sad to write this.
-  for(uword c = 0; c < n_cols; ++c)
-    {
-    for(uword r = 0; r < n_rows; ++r)
-      {
-      at(r, c) /= x.at(r, c);
-      }
-    }
-
-  return *this;
-  }
-
-
-
-template<typename eT>
 template<typename T1>
 inline
 SpMat<eT>::SpMat(const Base<eT, T1>& x)
@@ -866,6 +941,8 @@ SpMat<eT>::operator+=(const Base<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
   
+  sync_csc();
+  
   return (*this).operator=( (*this) + x.get_ref() );
   }
 
@@ -878,6 +955,8 @@ SpMat<eT>&
 SpMat<eT>::operator-=(const Base<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
+  
+  sync_csc();
   
   return (*this).operator=( (*this) - x.get_ref() );
   }
@@ -892,6 +971,8 @@ SpMat<eT>::operator*=(const Base<eT, T1>& y)
   {
   arma_extra_debug_sigprint();
 
+  sync_csc();
+  
   const Proxy<T1> p(y.get_ref());
 
   arma_debug_assert_mul_size(n_rows, n_cols, p.get_n_rows(), p.get_n_cols(), "matrix multiplication");
@@ -990,6 +1071,8 @@ SpMat<eT>::operator/=(const Base<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
 
+  sync_csc();
+  
   SpMat<eT> tmp = (*this) / x.get_ref();
   
   steal_mem(tmp);
@@ -1007,6 +1090,8 @@ SpMat<eT>::operator%=(const Base<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
 
+  sync_csc();
+  
   const Proxy<T1> p(x.get_ref());
   
   arma_debug_assert_same_size(n_rows, n_cols, p.get_n_rows(), p.get_n_cols(), "element-wise multiplication");
@@ -1088,6 +1173,8 @@ SpMat<eT>::operator=(const SpSubview<eT>& X)
   {
   arma_extra_debug_sigprint();
   
+  X.m.sync_csc();
+  
   const uword in_n_cols = X.n_cols;
   const uword in_n_rows = X.n_rows;
   
@@ -1138,6 +1225,8 @@ SpMat<eT>::operator+=(const SpSubview<eT>& X)
   {
   arma_extra_debug_sigprint();
   
+  sync_csc();
+  
   SpMat<eT> tmp = (*this) + X;
   
   steal_mem(tmp);
@@ -1153,6 +1242,8 @@ SpMat<eT>&
 SpMat<eT>::operator-=(const SpSubview<eT>& X)
   {
   arma_extra_debug_sigprint();
+  
+  sync_csc();
   
   SpMat<eT> tmp = (*this) - X;
   
@@ -1170,6 +1261,8 @@ SpMat<eT>::operator*=(const SpSubview<eT>& y)
   {
   arma_extra_debug_sigprint();
   
+  sync_csc();
+  
   SpMat<eT> z = (*this) * y;
   
   steal_mem(z);
@@ -1185,6 +1278,8 @@ SpMat<eT>&
 SpMat<eT>::operator%=(const SpSubview<eT>& x)
   {
   arma_extra_debug_sigprint();
+  
+  sync_csc();
   
   SpMat<eT> tmp = (*this) % x;
   
@@ -1216,6 +1311,109 @@ SpMat<eT>::operator/=(const SpSubview<eT>& x)
 
 
 template<typename eT>
+inline
+SpMat<eT>::SpMat(const spdiagview<eT>& X)
+  : n_rows(0)
+  , n_cols(0)
+  , n_elem(0)
+  , n_nonzero(0)
+  , vec_state(0)
+  , values(NULL) // extra element added when mem_resize is called
+  , row_indices(NULL)
+  , col_ptrs(NULL)
+  {
+  arma_extra_debug_sigprint_this(this);
+
+  spdiagview<eT>::extract(*this, X);
+  }
+
+
+
+template<typename eT>
+inline
+SpMat<eT>&
+SpMat<eT>::operator=(const spdiagview<eT>& X)
+  {
+  arma_extra_debug_sigprint();
+  
+  spdiagview<eT>::extract(*this, X);
+  
+  return *this;
+  }
+
+
+
+template<typename eT>
+inline
+SpMat<eT>&
+SpMat<eT>::operator+=(const spdiagview<eT>& X)
+  {
+  arma_extra_debug_sigprint();
+  
+  const SpMat<eT> tmp(X);
+  
+  return (*this).operator+=(tmp);
+  }
+
+
+
+template<typename eT>
+inline
+SpMat<eT>&
+SpMat<eT>::operator-=(const spdiagview<eT>& X)
+  {
+  arma_extra_debug_sigprint();
+  
+  const SpMat<eT> tmp(X);
+  
+  return (*this).operator-=(tmp);
+  }
+
+
+
+template<typename eT>
+inline
+SpMat<eT>&
+SpMat<eT>::operator*=(const spdiagview<eT>& X)
+  {
+  arma_extra_debug_sigprint();
+  
+  const SpMat<eT> tmp(X);
+  
+  return (*this).operator*=(tmp);
+  }
+
+
+
+template<typename eT>
+inline
+SpMat<eT>&
+SpMat<eT>::operator%=(const spdiagview<eT>& X)
+  {
+  arma_extra_debug_sigprint();
+  
+  const SpMat<eT> tmp(X);
+  
+  return (*this).operator%=(tmp);
+  }
+
+
+
+template<typename eT>
+inline
+SpMat<eT>&
+SpMat<eT>::operator/=(const spdiagview<eT>& X)
+  {
+  arma_extra_debug_sigprint();
+  
+  const SpMat<eT> tmp(X);
+  
+  return (*this).operator/=(tmp);
+  }
+
+
+
+template<typename eT>
 template<typename T1, typename spop_type>
 inline
 SpMat<eT>::SpMat(const SpOp<T1, spop_type>& X)
@@ -1233,6 +1431,9 @@ SpMat<eT>::SpMat(const SpOp<T1, spop_type>& X)
   arma_type_check(( is_same_type< eT, typename T1::elem_type >::no ));
   
   spop_type::apply(*this, X);
+  
+  sync_csc();          // in case apply() used element accessors
+  invalidate_cache();  // in case apply() modified the CSC representation
   }
 
 
@@ -1249,6 +1450,9 @@ SpMat<eT>::operator=(const SpOp<T1, spop_type>& X)
   
   spop_type::apply(*this, X);
   
+  sync_csc();          // in case apply() used element accessors
+  invalidate_cache();  // in case apply() modified the CSC representation
+  
   return *this;
   }
 
@@ -1263,6 +1467,8 @@ SpMat<eT>::operator+=(const SpOp<T1, spop_type>& X)
   arma_extra_debug_sigprint();
   
   arma_type_check(( is_same_type< eT, typename T1::elem_type >::no ));
+  
+  sync_csc();
   
   const SpMat<eT> m(X);
   
@@ -1281,6 +1487,8 @@ SpMat<eT>::operator-=(const SpOp<T1, spop_type>& X)
   
   arma_type_check(( is_same_type< eT, typename T1::elem_type >::no ));
   
+  sync_csc();
+  
   const SpMat<eT> m(X);
   
   return (*this).operator-=(m);
@@ -1297,6 +1505,8 @@ SpMat<eT>::operator*=(const SpOp<T1, spop_type>& X)
   arma_extra_debug_sigprint();
   
   arma_type_check(( is_same_type< eT, typename T1::elem_type >::no ));
+  
+  sync_csc();
   
   const SpMat<eT> m(X);
   
@@ -1315,6 +1525,8 @@ SpMat<eT>::operator%=(const SpOp<T1, spop_type>& X)
   
   arma_type_check(( is_same_type< eT, typename T1::elem_type >::no ));
   
+  sync_csc();
+  
   const SpMat<eT> m(X);
   
   return (*this).operator%=(m);
@@ -1331,6 +1543,8 @@ SpMat<eT>::operator/=(const SpOp<T1, spop_type>& X)
   arma_extra_debug_sigprint();
   
   arma_type_check(( is_same_type< eT, typename T1::elem_type >::no ));
+  
+  sync_csc();
   
   const SpMat<eT> m(X);
   
@@ -1357,6 +1571,9 @@ SpMat<eT>::SpMat(const SpGlue<T1, T2, spglue_type>& X)
   arma_type_check(( is_same_type< eT, typename T1::elem_type >::no ));
   
   spglue_type::apply(*this, X);
+  
+  sync_csc();          // in case apply() used element accessors
+  invalidate_cache();  // in case apply() modified the CSC representation
   }
 
 
@@ -1377,6 +1594,9 @@ SpMat<eT>::SpMat(const mtSpOp<eT, T1, spop_type>& X)
   arma_extra_debug_sigprint_this(this);
 
   spop_type::apply(*this, X);
+  
+  sync_csc();          // in case apply() used element accessors
+  invalidate_cache();  // in case apply() modified the CSC representation
   }
 
 
@@ -1390,6 +1610,9 @@ SpMat<eT>::operator=(const mtSpOp<eT, T1, spop_type>& X)
   arma_extra_debug_sigprint();
 
   spop_type::apply(*this, X);
+  
+  sync_csc();          // in case apply() used element accessors
+  invalidate_cache();  // in case apply() modified the CSC representation
 
   return *this;
   }
@@ -1403,7 +1626,9 @@ SpMat<eT>&
 SpMat<eT>::operator+=(const mtSpOp<eT, T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
-
+  
+  sync_csc();
+  
   const SpMat<eT> m(X);
 
   return (*this).operator+=(m);
@@ -1418,7 +1643,9 @@ SpMat<eT>&
 SpMat<eT>::operator-=(const mtSpOp<eT, T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
-
+  
+  sync_csc();
+  
   const SpMat<eT> m(X);
 
   return (*this).operator-=(m);
@@ -1433,7 +1660,9 @@ SpMat<eT>&
 SpMat<eT>::operator*=(const mtSpOp<eT, T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
-
+  
+  sync_csc();
+  
   const SpMat<eT> m(X);
 
   return (*this).operator*=(m);
@@ -1448,7 +1677,9 @@ SpMat<eT>&
 SpMat<eT>::operator%=(const mtSpOp<eT, T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
-
+  
+  sync_csc();
+  
   const SpMat<eT> m(X);
 
   return (*this).operator%=(m);
@@ -1463,7 +1694,9 @@ SpMat<eT>&
 SpMat<eT>::operator/=(const mtSpOp<eT, T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
-
+  
+  sync_csc();
+  
   const SpMat<eT> m(X);
 
   return (*this).operator/=(m);
@@ -1483,6 +1716,9 @@ SpMat<eT>::operator=(const SpGlue<T1, T2, spglue_type>& X)
   
   spglue_type::apply(*this, X);
   
+  sync_csc();          // in case apply() used element accessors
+  invalidate_cache();  // in case apply() modified the CSC representation
+  
   return *this;
   }
 
@@ -1497,6 +1733,8 @@ SpMat<eT>::operator+=(const SpGlue<T1, T2, spglue_type>& X)
   arma_extra_debug_sigprint();
   
   arma_type_check(( is_same_type< eT, typename T1::elem_type >::no ));
+  
+  sync_csc();
   
   const SpMat<eT> m(X);
   
@@ -1515,6 +1753,8 @@ SpMat<eT>::operator-=(const SpGlue<T1, T2, spglue_type>& X)
   
   arma_type_check(( is_same_type< eT, typename T1::elem_type >::no ));
   
+  sync_csc();
+  
   const SpMat<eT> m(X);
   
   return (*this).operator-=(m);
@@ -1531,6 +1771,8 @@ SpMat<eT>::operator*=(const SpGlue<T1, T2, spglue_type>& X)
   arma_extra_debug_sigprint();
   
   arma_type_check(( is_same_type< eT, typename T1::elem_type >::no ));
+  
+  sync_csc();
   
   const SpMat<eT> m(X);
   
@@ -1549,6 +1791,8 @@ SpMat<eT>::operator%=(const SpGlue<T1, T2, spglue_type>& X)
   
   arma_type_check(( is_same_type< eT, typename T1::elem_type >::no ));
   
+  sync_csc();
+  
   const SpMat<eT> m(X);
   
   return (*this).operator%=(m);
@@ -1566,6 +1810,8 @@ SpMat<eT>::operator/=(const SpGlue<T1, T2, spglue_type>& X)
   
   arma_type_check(( is_same_type< eT, typename T1::elem_type >::no ));
   
+  sync_csc();
+  
   const SpMat<eT> m(X);
   
   return (*this).operator/=(m);
@@ -1579,7 +1825,7 @@ SpSubview<eT>
 SpMat<eT>::row(const uword row_num)
   {
   arma_extra_debug_sigprint();
-
+  
   arma_debug_check(row_num >= n_rows, "SpMat::row(): out of bounds");
 
   return SpSubview<eT>(*this, row_num, 0, 1, n_cols);
@@ -1593,7 +1839,7 @@ const SpSubview<eT>
 SpMat<eT>::row(const uword row_num) const
   {
   arma_extra_debug_sigprint();
-
+  
   arma_debug_check(row_num >= n_rows, "SpMat::row(): out of bounds");
 
   return SpSubview<eT>(*this, row_num, 0, 1, n_cols);
@@ -1665,7 +1911,7 @@ SpSubview<eT>
 SpMat<eT>::col(const uword col_num)
   {
   arma_extra_debug_sigprint();
-
+  
   arma_debug_check(col_num >= n_cols, "SpMat::col(): out of bounds");
 
   return SpSubview<eT>(*this, 0, col_num, n_rows, 1);
@@ -1679,7 +1925,7 @@ const SpSubview<eT>
 SpMat<eT>::col(const uword col_num) const
   {
   arma_extra_debug_sigprint();
-
+  
   arma_debug_check(col_num >= n_cols, "SpMat::col(): out of bounds");
 
   return SpSubview<eT>(*this, 0, col_num, n_rows, 1);
@@ -1751,7 +1997,7 @@ SpSubview<eT>
 SpMat<eT>::rows(const uword in_row1, const uword in_row2)
   {
   arma_extra_debug_sigprint();
-
+  
   arma_debug_check
     (
     (in_row1 > in_row2) || (in_row2 >= n_rows),
@@ -1771,7 +2017,7 @@ const SpSubview<eT>
 SpMat<eT>::rows(const uword in_row1, const uword in_row2) const
   {
   arma_extra_debug_sigprint();
-
+  
   arma_debug_check
     (
     (in_row1 > in_row2) || (in_row2 >= n_rows),
@@ -1791,7 +2037,7 @@ SpSubview<eT>
 SpMat<eT>::cols(const uword in_col1, const uword in_col2)
   {
   arma_extra_debug_sigprint();
-
+  
   arma_debug_check
     (
     (in_col1 > in_col2) || (in_col2 >= n_cols),
@@ -1811,7 +2057,7 @@ const SpSubview<eT>
 SpMat<eT>::cols(const uword in_col1, const uword in_col2) const
   {
   arma_extra_debug_sigprint();
-
+  
   arma_debug_check
     (
     (in_col1 > in_col2) || (in_col2 >= n_cols),
@@ -1831,7 +2077,7 @@ SpSubview<eT>
 SpMat<eT>::submat(const uword in_row1, const uword in_col1, const uword in_row2, const uword in_col2)
   {
   arma_extra_debug_sigprint();
-
+  
   arma_debug_check
     (
     (in_row1 > in_row2) || (in_col1 >  in_col2) || (in_row2 >= n_rows) || (in_col2 >= n_cols),
@@ -1852,7 +2098,7 @@ const SpSubview<eT>
 SpMat<eT>::submat(const uword in_row1, const uword in_col1, const uword in_row2, const uword in_col2) const
   {
   arma_extra_debug_sigprint();
-
+  
   arma_debug_check
     (
     (in_row1 > in_row2) || (in_col1 >  in_col2) || (in_row2 >= n_rows) || (in_col2 >= n_cols),
@@ -1921,7 +2167,7 @@ SpSubview<eT>
 SpMat<eT>::submat(const span& row_span, const span& col_span)
   {
   arma_extra_debug_sigprint();
-
+  
   const bool row_all = row_span.whole;
   const bool col_all = col_span.whole;
   
@@ -1956,7 +2202,7 @@ const SpSubview<eT>
 SpMat<eT>::submat(const span& row_span, const span& col_span) const
   {
   arma_extra_debug_sigprint();
-
+  
   const bool row_all = row_span.whole;
   const bool col_all = col_span.whole;
   
@@ -1991,7 +2237,7 @@ SpSubview<eT>
 SpMat<eT>::operator()(const span& row_span, const span& col_span)
   {
   arma_extra_debug_sigprint();
-
+  
   return submat(row_span, col_span);
   }
 
@@ -2003,7 +2249,7 @@ const SpSubview<eT>
 SpMat<eT>::operator()(const span& row_span, const span& col_span) const
   {
   arma_extra_debug_sigprint();
-
+  
   return submat(row_span, col_span);
   }
 
@@ -2207,7 +2453,7 @@ void
 SpMat<eT>::swap_rows(const uword in_row1, const uword in_row2)
   {
   arma_extra_debug_sigprint();
-
+  
   arma_debug_check
     (
     (in_row1 >= n_rows) || (in_row2 >= n_rows),
@@ -2219,7 +2465,10 @@ SpMat<eT>::swap_rows(const uword in_row1, const uword in_row2)
     {
     return;
     }
-
+  
+  sync_csc();
+  invalidate_cache();
+  
   // The easier way to do this, instead of collecting all the elements in one row and then swapping with the other, will be
   // to iterate over each column of the matrix (since we store in column-major format) and then swap the two elements in the two rows at that time.
   // We will try to avoid using the at() call since it is expensive, instead preferring to use an iterator to track our position.
@@ -2317,12 +2566,12 @@ void
 SpMat<eT>::swap_cols(const uword in_col1, const uword in_col2)
   {
   arma_extra_debug_sigprint();
-
+  
   // slow but works
   for(uword lrow = 0; lrow < n_rows; ++lrow)
     {
-    eT tmp = at(lrow, in_col1);
-    at(lrow, in_col1) = at(lrow, in_col2);
+    const eT tmp = at(lrow, in_col1);
+    at(lrow, in_col1) = eT( at(lrow, in_col2) );
     at(lrow, in_col2) = tmp;
     }
   }
@@ -2335,6 +2584,7 @@ void
 SpMat<eT>::shed_row(const uword row_num)
   {
   arma_extra_debug_sigprint();
+  
   arma_debug_check (row_num >= n_rows, "SpMat::shed_row(): out of bounds");
 
   shed_rows (row_num, row_num);
@@ -2348,6 +2598,7 @@ void
 SpMat<eT>::shed_col(const uword col_num)
   {
   arma_extra_debug_sigprint();
+  
   arma_debug_check (col_num >= n_cols, "SpMat::shed_col(): out of bounds");
 
   shed_cols(col_num, col_num);
@@ -2367,6 +2618,8 @@ SpMat<eT>::shed_rows(const uword in_row1, const uword in_row2)
     (in_row1 > in_row2) || (in_row2 >= n_rows),
     "SpMat::shed_rows(): indices out of bounds or incorectly used"
     );
+  
+  sync_csc();
   
   SpMat<eT> newmat(n_rows - (in_row2 - in_row1 + 1), n_cols);
   
@@ -2445,13 +2698,16 @@ void
 SpMat<eT>::shed_cols(const uword in_col1, const uword in_col2)
   {
   arma_extra_debug_sigprint();
-
+  
   arma_debug_check
     (
     (in_col1 > in_col2) || (in_col2 >= n_cols),
     "SpMat::shed_cols(): indices out of bounds or incorrectly used"
     );
-
+  
+  sync_csc();
+  invalidate_cache();
+  
   // First we find the locations in values and row_indices for the column entries.
   uword col_beg = col_ptrs[in_col1];
   uword col_end = col_ptrs[in_col2 + 1];
@@ -2525,10 +2781,12 @@ SpMat<eT>::shed_cols(const uword in_col1, const uword in_col2)
 template<typename eT>
 arma_inline
 arma_warn_unused
-SpValProxy<SpMat<eT> >
+MapMat_elem<eT>
 SpMat<eT>::operator[](const uword i)
   {
-  return get_value(i);
+  sync_cache();
+  
+  return cache.elem(i, sync_state, access::rw(n_nonzero));
   }
 
 
@@ -2547,10 +2805,12 @@ SpMat<eT>::operator[](const uword i) const
 template<typename eT>
 arma_inline
 arma_warn_unused
-SpValProxy<SpMat<eT> >
+MapMat_elem<eT>
 SpMat<eT>::at(const uword i)
   {
-  return get_value(i);
+  sync_cache();
+  
+  return cache.elem(i, sync_state, access::rw(n_nonzero));
   }
 
 
@@ -2569,11 +2829,14 @@ SpMat<eT>::at(const uword i) const
 template<typename eT>
 arma_inline
 arma_warn_unused
-SpValProxy<SpMat<eT> >
+MapMat_elem<eT>
 SpMat<eT>::operator()(const uword i)
   {
   arma_debug_check( (i >= n_elem), "SpMat::operator(): out of bounds");
-  return get_value(i);
+  
+  sync_cache();
+  
+  return cache.elem(i, sync_state, access::rw(n_nonzero));
   }
 
 
@@ -2585,6 +2848,7 @@ eT
 SpMat<eT>::operator()(const uword i) const
   {
   arma_debug_check( (i >= n_elem), "SpMat::operator(): out of bounds");
+  
   return get_value(i);
   }
 
@@ -2598,10 +2862,12 @@ SpMat<eT>::operator()(const uword i) const
 template<typename eT>
 arma_inline
 arma_warn_unused
-SpValProxy<SpMat<eT> >
+MapMat_elem<eT>
 SpMat<eT>::at(const uword in_row, const uword in_col)
   {
-  return get_value(in_row, in_col);
+  sync_cache();
+  
+  return cache.elem(in_row, in_col, sync_state, access::rw(n_nonzero));
   }
 
 
@@ -2620,11 +2886,14 @@ SpMat<eT>::at(const uword in_row, const uword in_col) const
 template<typename eT>
 arma_inline
 arma_warn_unused
-SpValProxy<SpMat<eT> >
+MapMat_elem<eT>
 SpMat<eT>::operator()(const uword in_row, const uword in_col)
   {
   arma_debug_check( ((in_row >= n_rows) || (in_col >= n_cols)), "SpMat::operator(): out of bounds");
-  return get_value(in_row, in_col);
+  
+  sync_cache();
+  
+  return cache.elem(in_row, in_col, sync_state, access::rw(n_nonzero));
   }
 
 
@@ -2636,6 +2905,7 @@ eT
 SpMat<eT>::operator()(const uword in_row, const uword in_col) const
   {
   arma_debug_check( ((in_row >= n_rows) || (in_col >= n_cols)), "SpMat::operator(): out of bounds");
+  
   return get_value(in_row, in_col);
   }
 
@@ -2650,7 +2920,7 @@ arma_warn_unused
 bool
 SpMat<eT>::is_empty() const
   {
-  return(n_elem == 0);
+  return (n_elem == 0);
   }
 
 
@@ -2712,6 +2982,8 @@ SpMat<eT>::is_finite() const
   {
   arma_extra_debug_sigprint();
   
+  sync_csc();
+  
   return arrayops::is_finite(values, n_nonzero);
   }
 
@@ -2725,6 +2997,8 @@ SpMat<eT>::has_inf() const
   {
   arma_extra_debug_sigprint();
   
+  sync_csc();
+  
   return arrayops::has_inf(values, n_nonzero);
   }
 
@@ -2737,6 +3011,8 @@ bool
 SpMat<eT>::has_nan() const
   {
   arma_extra_debug_sigprint();
+  
+  sync_csc();
   
   return arrayops::has_nan(values, n_nonzero);
   }
@@ -2886,16 +3162,18 @@ SpMat<eT>::impl_print(const std::string& extra_text) const
   {
   arma_extra_debug_sigprint();
 
+  sync_csc();
+  
   if(extra_text.length() != 0)
     {
-    const std::streamsize orig_width = ARMA_DEFAULT_OSTREAM.width();
-
-    ARMA_DEFAULT_OSTREAM << extra_text << '\n';
-
-    ARMA_DEFAULT_OSTREAM.width(orig_width);
+    const std::streamsize orig_width = get_cout_stream().width();
+    
+    get_cout_stream() << extra_text << '\n';
+    
+    get_cout_stream().width(orig_width);
     }
-
-  arma_ostream::print(ARMA_DEFAULT_OSTREAM, *this, true);
+  
+  arma_ostream::print(get_cout_stream(), *this, true);
   }
 
 
@@ -2907,6 +3185,8 @@ SpMat<eT>::impl_print(std::ostream& user_stream, const std::string& extra_text) 
   {
   arma_extra_debug_sigprint();
 
+  sync_csc();
+  
   if(extra_text.length() != 0)
     {
     const std::streamsize orig_width = user_stream.width();
@@ -2928,16 +3208,18 @@ SpMat<eT>::impl_raw_print(const std::string& extra_text) const
   {
   arma_extra_debug_sigprint();
 
+  sync_csc();
+  
   if(extra_text.length() != 0)
     {
-    const std::streamsize orig_width = ARMA_DEFAULT_OSTREAM.width();
+    const std::streamsize orig_width = get_cout_stream().width();
 
-    ARMA_DEFAULT_OSTREAM << extra_text << '\n';
+    get_cout_stream() << extra_text << '\n';
 
-    ARMA_DEFAULT_OSTREAM.width(orig_width);
+    get_cout_stream().width(orig_width);
     }
 
-  arma_ostream::print(ARMA_DEFAULT_OSTREAM, *this, false);
+  arma_ostream::print(get_cout_stream(), *this, false);
   }
 
 
@@ -2948,6 +3230,8 @@ SpMat<eT>::impl_raw_print(std::ostream& user_stream, const std::string& extra_te
   {
   arma_extra_debug_sigprint();
 
+  sync_csc();
+  
   if(extra_text.length() != 0)
     {
     const std::streamsize orig_width = user_stream.width();
@@ -2973,16 +3257,18 @@ SpMat<eT>::impl_print_dense(const std::string& extra_text) const
   {
   arma_extra_debug_sigprint();
 
+  sync_csc();
+  
   if(extra_text.length() != 0)
     {
-    const std::streamsize orig_width = ARMA_DEFAULT_OSTREAM.width();
+    const std::streamsize orig_width = get_cout_stream().width();
 
-    ARMA_DEFAULT_OSTREAM << extra_text << '\n';
+    get_cout_stream() << extra_text << '\n';
 
-    ARMA_DEFAULT_OSTREAM.width(orig_width);
+    get_cout_stream().width(orig_width);
     }
 
-  arma_ostream::print_dense(ARMA_DEFAULT_OSTREAM, *this, true);
+  arma_ostream::print_dense(get_cout_stream(), *this, true);
   }
 
 
@@ -2994,6 +3280,8 @@ SpMat<eT>::impl_print_dense(std::ostream& user_stream, const std::string& extra_
   {
   arma_extra_debug_sigprint();
 
+  sync_csc();
+  
   if(extra_text.length() != 0)
     {
     const std::streamsize orig_width = user_stream.width();
@@ -3015,16 +3303,18 @@ SpMat<eT>::impl_raw_print_dense(const std::string& extra_text) const
   {
   arma_extra_debug_sigprint();
 
+  sync_csc();
+  
   if(extra_text.length() != 0)
     {
-    const std::streamsize orig_width = ARMA_DEFAULT_OSTREAM.width();
+    const std::streamsize orig_width = get_cout_stream().width();
 
-    ARMA_DEFAULT_OSTREAM << extra_text << '\n';
+    get_cout_stream() << extra_text << '\n';
 
-    ARMA_DEFAULT_OSTREAM.width(orig_width);
+    get_cout_stream().width(orig_width);
     }
 
-  arma_ostream::print_dense(ARMA_DEFAULT_OSTREAM, *this, false);
+  arma_ostream::print_dense(get_cout_stream(), *this, false);
   }
 
 
@@ -3036,6 +3326,8 @@ SpMat<eT>::impl_raw_print_dense(std::ostream& user_stream, const std::string& ex
   {
   arma_extra_debug_sigprint();
 
+  sync_csc();
+  
   if(extra_text.length() != 0)
     {
     const std::streamsize orig_width = user_stream.width();
@@ -3058,7 +3350,7 @@ void
 SpMat<eT>::copy_size(const SpMat<eT2>& m)
   {
   arma_extra_debug_sigprint();
-
+  
   set_size(m.n_rows, m.n_cols);
   }
 
@@ -3103,6 +3395,8 @@ void
 SpMat<eT>::set_size(const uword in_rows, const uword in_cols)
   {
   arma_extra_debug_sigprint();
+  
+  invalidate_cache(); // placed here, as set_size() is used during matrix modification
   
   if( (n_rows == in_rows) && (n_cols == in_cols) )
     {
@@ -3150,6 +3444,8 @@ SpMat<eT>::resize(const uword in_rows, const uword in_cols)
   
   if(tmp.n_elem > 0)
     {
+    sync_csc();
+    
     const uword last_row = (std::min)(in_rows, n_rows) - 1;
     const uword last_col = (std::min)(in_cols, n_cols) - 1;
     
@@ -3183,6 +3479,9 @@ SpMat<eT>::reshape(const uword in_rows, const uword in_cols)
   arma_check( ((in_rows*in_cols) != n_elem), "SpMat::reshape(): changing the number of elements in a sparse matrix is currently not supported" );
   
   if( (n_rows == in_rows) && (n_cols == in_cols) )  { return; }
+  
+  sync_csc();
+  invalidate_cache();
   
   // We have to modify all of the relevant row indices and the relevant column pointers.
   // Iterate over all the points to do this.  We won't be deleting any points, but we will be modifying
@@ -3253,6 +3552,8 @@ SpMat<eT>::reshape(const uword in_rows, const uword in_cols, const uword dim)
     {
     arma_check( ((in_rows*in_cols) != n_elem), "SpMat::reshape(): changing the number of elements in a sparse matrix is currently not supported" );
     
+    sync_csc();
+    
     // Row-wise reshaping.  This is more tedious and we will use a separate sparse matrix to do it.
     SpMat<eT> tmp(in_rows, in_cols);
     
@@ -3282,6 +3583,9 @@ SpMat<eT>::replace(const eT old_val, const eT new_val)
     }
   else
     {
+    sync_csc();
+    invalidate_cache();
+    
     arrayops::replace(access::rwp(values), n_nonzero, old_val, new_val);
     
     if(new_val == eT(0))  { remove_zeros(); }
@@ -3687,6 +3991,8 @@ SpMat<eT>::save(const std::string name, const file_type type, const bool print_s
   {
   arma_extra_debug_sigprint();
   
+  sync_csc();
+  
   bool save_okay;
   
   switch(type)
@@ -3704,7 +4010,6 @@ SpMat<eT>::save(const std::string name, const file_type type, const bool print_s
       break;
     
     case coord_ascii:
-      arma_debug_warn("SpMat::save(): support for coord format is experimental");
       save_okay = diskio::save_coord_ascii(*this, name);
       break;
     
@@ -3728,6 +4033,8 @@ SpMat<eT>::save(std::ostream& os, const file_type type, const bool print_status)
   {
   arma_extra_debug_sigprint();
   
+  sync_csc();
+  
   bool save_okay;
   
   switch(type)
@@ -3745,7 +4052,6 @@ SpMat<eT>::save(std::ostream& os, const file_type type, const bool print_status)
       break;
     
     case coord_ascii:
-      arma_debug_warn("SpMat::save(): support for coord format is experimental");
       save_okay = diskio::save_coord_ascii(*this, os);
       break;
     
@@ -3769,6 +4075,8 @@ SpMat<eT>::load(const std::string name, const file_type type, const bool print_s
   {
   arma_extra_debug_sigprint();
   
+  invalidate_cache();
+  
   bool load_okay;
   std::string err_msg;
   
@@ -3791,7 +4099,6 @@ SpMat<eT>::load(const std::string name, const file_type type, const bool print_s
       break;
     
     case coord_ascii:
-      arma_debug_warn("SpMat::load(): support for coord format is experimental");
       load_okay = diskio::load_coord_ascii(*this, name, err_msg);
       break;
     
@@ -3830,6 +4137,8 @@ SpMat<eT>::load(std::istream& is, const file_type type, const bool print_status)
   {
   arma_extra_debug_sigprint();
   
+  invalidate_cache();
+  
   bool load_okay;
   std::string err_msg;
   
@@ -3852,7 +4161,6 @@ SpMat<eT>::load(std::istream& is, const file_type type, const bool print_status)
       break;
     
     case coord_ascii:
-      arma_debug_warn("SpMat::load(): support for coord format is experimental");
       load_okay = diskio::load_coord_ascii(*this, is, err_msg);
       break;
     
@@ -3945,6 +4253,8 @@ SpMat<eT>::init(uword in_rows, uword in_cols)
   {
   arma_extra_debug_sigprint();
   
+  invalidate_cache(); // placed here, as init() is used during matrix modification
+  
   // Verify that we are allowed to do this.
   if(vec_state > 0)
     {
@@ -4029,7 +4339,7 @@ void
 SpMat<eT>::init(const std::string& text)
   {
   arma_extra_debug_sigprint();
-
+  
   // Figure out the size first.
   uword t_n_rows = 0;
   uword t_n_cols = 0;
@@ -4101,12 +4411,8 @@ SpMat<eT>::init(const std::string& text)
 
     while (line_stream >> val)
       {
-      // Only add nonzero elements.
-      if (val != eT(0))
-        {
-        get_value(lrow, lcol) = val;
-        }
-
+      if(val != eT(0))  { at(lrow, lcol) = val; }
+      
       ++lcol;
       }
 
@@ -4130,6 +4436,8 @@ SpMat<eT>::init(const SpMat<eT>& x)
   // Ensure we are not initializing to ourselves.
   if (this != &x)
     {
+    x.sync_csc();
+    
     init(x.n_rows, x.n_cols);
 
     // values and row_indices may not be null.
@@ -4148,6 +4456,54 @@ SpMat<eT>::init(const SpMat<eT>& x)
     arrayops::copy(access::rwp(col_ptrs),    x.col_ptrs,    x.n_cols + 1);
     
     access::rw(n_nonzero) = x.n_nonzero;
+    }
+  }
+
+
+
+template<typename eT>
+inline
+void
+SpMat<eT>::init(const MapMat<eT>& x)
+  {
+  arma_extra_debug_sigprint();
+  
+  const uword x_n_rows = x.n_rows;
+  const uword x_n_cols = x.n_cols;
+  const uword x_n_nz   = x.get_n_nonzero();
+  
+  init(x_n_rows, x_n_cols);
+  
+  mem_resize(x_n_nz);
+  
+  arrayops::inplace_set(access::rwp(col_ptrs), uword(0), x_n_cols + 1);
+  
+  typename MapMat<eT>::map_type& x_map_ref = *(x.map_ptr);
+  
+  typename MapMat<eT>::map_type::const_iterator x_it = x_map_ref.begin();
+  
+  for(uword i=0; i < x_n_nz; ++i)
+    {
+    const std::pair<uword, eT>& x_entry = (*x_it);
+    
+    const uword x_index = x_entry.first;
+    const eT    x_val   = x_entry.second;
+    
+    const uword x_row = x_index % x_n_rows;
+    const uword x_col = x_index / x_n_rows;
+    
+    access::rw(values[i])      = x_val;
+    access::rw(row_indices[i]) = x_row;
+    
+    access::rw(col_ptrs[ x_col + 1 ])++;
+    
+    ++x_it;
+    }
+  
+  
+  for(uword i = 0; i < x_n_cols; ++i)
+    {
+    access::rw(col_ptrs[i + 1]) += col_ptrs[i];
     }
   }
 
@@ -4439,6 +4795,8 @@ SpMat<eT>::mem_resize(const uword new_n_nonzero)
   {
   arma_extra_debug_sigprint();
   
+  invalidate_cache();  // placed here, as mem_resize() is used during matrix modification
+  
   if(n_nonzero != new_n_nonzero)
     {
     if(new_n_nonzero == 0)
@@ -4448,13 +4806,13 @@ SpMat<eT>::mem_resize(const uword new_n_nonzero)
       
       access::rw(values)      = memory::acquire_chunked<eT>   (1);
       access::rw(row_indices) = memory::acquire_chunked<uword>(1);
-
+      
       access::rw(     values[0]) = 0;
       access::rw(row_indices[0]) = 0;
       }
     else
       {
-      // Figure out the actual amount of memory currently allocated
+      // Figure out the actual amount of memory currently allocated.
       // NOTE: this relies on memory::acquire_chunked() being used for the 'values' and 'row_indices' arrays
       const uword n_alloc = memory::enlarge_to_mult_of_chunksize(n_nonzero);
       
@@ -4478,9 +4836,9 @@ SpMat<eT>::mem_resize(const uword new_n_nonzero)
         access::rw(values)      = new_values;
         access::rw(row_indices) = new_row_indices;
         }
-        
-      // Set the "fake end" of the matrix by setting the last value and row
-      // index to 0.  This helps the iterators work correctly.
+      
+      // Set the "fake end" of the matrix by setting the last value and row index to 0.
+      // This helps the iterators work correctly.
       access::rw(     values[new_n_nonzero]) = 0;
       access::rw(row_indices[new_n_nonzero]) = 0;
       }
@@ -4494,9 +4852,25 @@ SpMat<eT>::mem_resize(const uword new_n_nonzero)
 template<typename eT>
 inline
 void
+SpMat<eT>::sync() const
+  {
+  arma_extra_debug_sigprint();
+  
+  sync_csc();
+  }
+
+
+
+template<typename eT>
+inline
+void
 SpMat<eT>::remove_zeros()
   {
   arma_extra_debug_sigprint();
+  
+  sync_csc();
+  
+  invalidate_cache();  // placed here, as remove_zeros() is used during matrix modification
   
   const uword old_n_nonzero = n_nonzero;
         uword new_n_nonzero = 0;
@@ -4555,6 +4929,27 @@ SpMat<eT>::steal_mem(SpMat<eT>& x)
   
   if(this != &x)
     {
+    x.sync_csc();
+    
+    steal_mem_simple(x);
+    
+    invalidate_cache();
+    
+    x.invalidate_cache();
+    }
+  }
+
+
+
+template<typename eT>
+inline
+void
+SpMat<eT>::steal_mem_simple(SpMat<eT>& x)
+  {
+  arma_extra_debug_sigprint();
+  
+  if(this != &x)
+    {
     if(values     )  { memory::release(access::rw(values));      }
     if(row_indices)  { memory::release(access::rw(row_indices)); }
     if(col_ptrs   )  { memory::release(access::rw(col_ptrs));    }
@@ -4600,12 +4995,18 @@ SpMat<eT>::init_xform(const SpBase<eT,T1>& A, const Functor& func)
     
     eT* t_values = access::rwp(values);
     
+    bool has_zero = false;
+    
     for(uword i=0; i < nnz; ++i)
       {
-      t_values[i] = func(t_values[i]);
+      eT& t_values_i = t_values[i];
+      
+      t_values_i = func(t_values_i);
+      
+      if(t_values_i == eT(0))  { has_zero = true; }
       }
     
-    remove_zeros();
+    if(has_zero)  { remove_zeros(); }
     }
   else
     {
@@ -4662,10 +5063,18 @@ SpMat<eT>::init_xform_mt(const SpBase<eT2,T1>& A, const Functor& func)
     const eT2* x_values = x.values;
           eT*  t_values = access::rwp(values);
     
+    bool has_zero = false;
+    
     for(uword i=0; i < nnz; ++i)
       {
-      t_values[i] = func(x_values[i]);   // NOTE: func() must produce a value of type eT (ie. act as a convertor between eT2 and eT)
+      eT& t_values_i = t_values[i];
+      
+      t_values_i = func(x_values[i]);   // NOTE: func() must produce a value of type eT (ie. act as a convertor between eT2 and eT)
+      
+      if(t_values_i == eT(0))  { has_zero = true; } 
       }
+    
+    if(has_zero)  { remove_zeros(); }
     }
   else
     {
@@ -4676,10 +5085,16 @@ SpMat<eT>::init_xform_mt(const SpBase<eT2,T1>& A, const Functor& func)
     typename SpProxy<T1>::const_iterator_type it     = P.begin();
     typename SpProxy<T1>::const_iterator_type it_end = P.end();
     
+    bool has_zero = false;
+    
     while(it != it_end)
       {
+      const eT val = func(*it);   // NOTE: func() must produce a value of type eT (ie. act as a convertor between eT2 and eT)
+      
+      if(val == eT(0))  { has_zero = true; }
+      
       access::rw(row_indices[it.pos()]) = it.row();
-      access::rw(values[it.pos()]) = func(*it);   // NOTE: func() must produce a value of type eT (ie. act as a convertor between eT2 and eT)
+      access::rw(values[it.pos()]) = val;
       ++access::rw(col_ptrs[it.col() + 1]);
       ++it;
       }
@@ -4689,9 +5104,9 @@ SpMat<eT>::init_xform_mt(const SpBase<eT2,T1>& A, const Functor& func)
       {
       access::rw(col_ptrs[c]) += col_ptrs[c - 1];
       }
+    
+    if(has_zero)  { remove_zeros(); }
     }
-  
-  remove_zeros();
   }
 
 
@@ -4702,6 +5117,8 @@ typename SpMat<eT>::iterator
 SpMat<eT>::begin()
   {
   arma_extra_debug_sigprint();
+  
+  sync_csc();
   
   return iterator(*this);
   }
@@ -4715,6 +5132,8 @@ SpMat<eT>::begin() const
   {
   arma_extra_debug_sigprint();
   
+  sync_csc();
+  
   return const_iterator(*this);
   }
 
@@ -4725,6 +5144,8 @@ inline
 typename SpMat<eT>::iterator
 SpMat<eT>::end()
   {
+  sync_csc();
+  
   return iterator(*this, 0, n_cols, n_nonzero);
   }
 
@@ -4735,6 +5156,8 @@ inline
 typename SpMat<eT>::const_iterator
 SpMat<eT>::end() const
   {
+  sync_csc();
+  
   return const_iterator(*this, 0, n_cols, n_nonzero);
   }
 
@@ -4745,6 +5168,8 @@ inline
 typename SpMat<eT>::iterator
 SpMat<eT>::begin_col(const uword col_num)
   {
+  sync_csc();
+  
   return iterator(*this, 0, col_num);
   }
 
@@ -4755,6 +5180,8 @@ inline
 typename SpMat<eT>::const_iterator
 SpMat<eT>::begin_col(const uword col_num) const
   {
+  sync_csc();
+  
   return const_iterator(*this, 0, col_num);
   }
 
@@ -4765,6 +5192,8 @@ inline
 typename SpMat<eT>::iterator
 SpMat<eT>::end_col(const uword col_num)
   {
+  sync_csc();
+  
   return iterator(*this, 0, col_num + 1);
   }
 
@@ -4775,6 +5204,8 @@ inline
 typename SpMat<eT>::const_iterator
 SpMat<eT>::end_col(const uword col_num) const
   {
+  sync_csc();
+  
   return const_iterator(*this, 0, col_num + 1);
   }
 
@@ -4785,6 +5216,8 @@ inline
 typename SpMat<eT>::row_iterator
 SpMat<eT>::begin_row(const uword row_num)
   {
+  sync_csc();
+  
   return row_iterator(*this, row_num, 0);
   }
 
@@ -4795,6 +5228,8 @@ inline
 typename SpMat<eT>::const_row_iterator
 SpMat<eT>::begin_row(const uword row_num) const
   {
+  sync_csc();
+  
   return const_row_iterator(*this, row_num, 0);
   }
 
@@ -4805,6 +5240,8 @@ inline
 typename SpMat<eT>::row_iterator
 SpMat<eT>::end_row()
   {
+  sync_csc();
+  
   return row_iterator(*this, n_nonzero);
   }
 
@@ -4815,6 +5252,8 @@ inline
 typename SpMat<eT>::const_row_iterator
 SpMat<eT>::end_row() const
   {
+  sync_csc();
+  
   return const_row_iterator(*this, n_nonzero);
   }
 
@@ -4825,6 +5264,8 @@ inline
 typename SpMat<eT>::row_iterator
 SpMat<eT>::end_row(const uword row_num)
   {
+  sync_csc();
+  
   return row_iterator(*this, row_num + 1, 0);
   }
 
@@ -4835,6 +5276,8 @@ inline
 typename SpMat<eT>::const_row_iterator
 SpMat<eT>::end_row(const uword row_num) const
   {
+  sync_csc();
+  
   return const_row_iterator(*this, row_num + 1, 0);
   }
 
@@ -4845,6 +5288,8 @@ inline
 typename SpMat<eT>::row_col_iterator
 SpMat<eT>::begin_row_col()
   {
+  sync_csc();
+  
   return begin();
   }
 
@@ -4855,6 +5300,8 @@ inline
 typename SpMat<eT>::const_row_col_iterator
 SpMat<eT>::begin_row_col() const
   {
+  sync_csc();
+  
   return begin();
   }
 
@@ -4864,6 +5311,8 @@ template<typename eT>
 inline typename SpMat<eT>::row_col_iterator
 SpMat<eT>::end_row_col()
   {
+  sync_csc();
+  
   return end();
   }
 
@@ -4874,6 +5323,8 @@ inline
 typename SpMat<eT>::const_row_col_iterator
 SpMat<eT>::end_row_col() const
   {
+  sync_csc();
+  
   return end();
   }
 
@@ -4948,6 +5399,8 @@ arma_warn_unused
 SpValProxy<SpMat<eT> >
 SpMat<eT>::get_value(const uword in_row, const uword in_col)
   {
+  sync_csc();
+  
   const uword colptr      = col_ptrs[in_col];
   const uword next_colptr = col_ptrs[in_col + 1];
 
@@ -4983,6 +5436,8 @@ arma_warn_unused
 eT
 SpMat<eT>::get_value(const uword in_row, const uword in_col) const
   {
+  sync_csc();
+  
   const uword colptr      = col_ptrs[in_col];
   const uword next_colptr = col_ptrs[in_col + 1];
   
@@ -5037,6 +5492,8 @@ arma_inline
 void
 SpMat<eT>::get_position(const uword i, uword& row_of_i, uword& col_of_i) const
   {
+  sync_csc();
+  
   arma_debug_check((i >= n_nonzero), "SpMat::get_position(): index out of bounds");
   
   col_of_i = 0;
@@ -5069,6 +5526,9 @@ eT&
 SpMat<eT>::add_element(const uword in_row, const uword in_col, const eT val)
   {
   arma_extra_debug_sigprint();
+  
+  sync_csc();
+  invalidate_cache();
   
   // We will assume the new element does not exist and begin the search for
   // where to insert it.  If we find that it already exists, we will then
@@ -5178,6 +5638,9 @@ SpMat<eT>::delete_element(const uword in_row, const uword in_col)
   {
   arma_extra_debug_sigprint();
   
+  sync_csc();
+  invalidate_cache();
+  
   // We assume the element exists (although... it may not) and look for its
   // exact position.  If it doesn't exist... well, we don't need to do anything.
   uword colptr      = col_ptrs[in_col];
@@ -5247,6 +5710,79 @@ SpMat<eT>::delete_element(const uword in_row, const uword in_col)
   
   return; // The element does not exist, so there's nothing for us to do.
   }
+
+
+
+template<typename eT>
+arma_inline
+void
+SpMat<eT>::invalidate_cache() const
+  {
+  arma_extra_debug_sigprint();
+  
+  cache.reset();
+  
+  sync_state = 0;
+  }
+
+
+
+template<typename eT>
+arma_inline
+void
+SpMat<eT>::invalidate_csc() const
+  {
+  arma_extra_debug_sigprint();
+  
+  sync_state = 1;
+  }
+
+
+
+template<typename eT>
+arma_inline
+void
+SpMat<eT>::sync_cache() const
+  {
+  arma_extra_debug_sigprint();
+  
+  if(sync_state == 0)
+    {
+    cache = (*this);
+    
+    sync_state = 2;
+    }
+  }
+
+
+
+
+template<typename eT>
+inline
+void
+SpMat<eT>::sync_csc() const
+  {
+  arma_extra_debug_sigprint();
+  
+  if(sync_state == 1)
+    {
+    SpMat<eT> tmp(cache);  // construct separate matrix to prevent the cache getting zapped
+    
+    // sync_state is only set to 1 by non-const element access operators,
+    // so the shenanigans with const_cast are to satisfy the compiler
+    
+    SpMat<eT>& x = const_cast< SpMat<eT>& >(*this);
+    
+    x.steal_mem_simple(tmp);
+    
+    sync_state = 2;
+    }
+  }
+
+
+
+//
+// SpMat_aux
 
 
 

--- a/inst/include/armadillo_bits/SpProxy.hpp
+++ b/inst/include/armadillo_bits/SpProxy.hpp
@@ -43,6 +43,7 @@ class SpProxy< SpMat<eT> >
     : Q(A)
     {
     arma_extra_debug_sigprint();
+    Q.sync();
     }
 
   arma_inline uword get_n_rows()    const { return Q.n_rows;    }
@@ -95,6 +96,7 @@ class SpProxy< SpCol<eT> >
     : Q(A)
     {
     arma_extra_debug_sigprint();
+    Q.sync();
     }
   
   arma_inline uword get_n_rows()    const { return Q.n_rows;    }
@@ -147,6 +149,7 @@ class SpProxy< SpRow<eT> >
     : Q(A)
     {
     arma_extra_debug_sigprint();
+    Q.sync();
     }
   
   arma_inline uword get_n_rows()    const { return 1;           }
@@ -199,6 +202,7 @@ class SpProxy< SpSubview<eT> >
     : Q(A)
     {
     arma_extra_debug_sigprint();
+    Q.m.sync();
     }
 
   arma_inline uword get_n_rows()    const { return Q.n_rows;    }
@@ -223,6 +227,58 @@ class SpProxy< SpSubview<eT> >
   
   template<typename eT2>
   arma_inline bool is_alias(const SpMat<eT2>& X) const { return (void_ptr(&Q.m) == void_ptr(&X)); }
+  };
+
+
+
+template<typename eT>
+class SpProxy< spdiagview<eT> >
+  {
+  public:
+  
+  typedef eT                                       elem_type;
+  typedef typename get_pod_type<elem_type>::result pod_type;
+  typedef SpMat<eT>                                stored_type;
+  
+  typedef typename SpMat<eT>::const_iterator       const_iterator_type;
+  typedef typename SpMat<eT>::const_row_iterator   const_row_iterator_type;
+  
+  static const bool use_iterator   = false;
+  static const bool Q_is_generated = true;
+  
+  static const bool is_row = false;
+  static const bool is_col = true;
+  
+  arma_aligned const SpMat<eT> Q;
+  
+  inline explicit SpProxy(const spdiagview<eT>& A)
+    : Q(A)
+    {
+    arma_extra_debug_sigprint();
+    }
+  
+  arma_inline uword get_n_rows()    const { return Q.n_rows;    }
+  arma_inline uword get_n_cols()    const { return Q.n_cols;    }
+  arma_inline uword get_n_elem()    const { return Q.n_elem;    }
+  arma_inline uword get_n_nonzero() const { return Q.n_nonzero; }
+  
+  arma_inline elem_type operator[](const uword i)                    const { return Q[i];           }
+  arma_inline elem_type at        (const uword row, const uword col) const { return Q.at(row, col); }
+  
+  arma_inline const eT*    get_values()      const { return Q.values;      }
+  arma_inline const uword* get_row_indices() const { return Q.row_indices; }
+  arma_inline const uword* get_col_ptrs()    const { return Q.col_ptrs;    }
+  
+  arma_inline const_iterator_type     begin()                            const { return Q.begin();            }
+  arma_inline const_iterator_type     begin_col(const uword col_num)     const { return Q.begin_col(col_num); }
+  arma_inline const_row_iterator_type begin_row(const uword row_num = 0) const { return Q.begin_row(row_num); }
+  
+  arma_inline const_iterator_type     end()                        const { return Q.end();            }
+  arma_inline const_row_iterator_type end_row()                    const { return Q.end_row();        }
+  arma_inline const_row_iterator_type end_row(const uword row_num) const { return Q.end_row(row_num); }
+  
+  template<typename eT2>
+  arma_inline bool is_alias(const SpMat<eT2>&) const { return false; }
   };
 
 
@@ -339,7 +395,6 @@ class SpProxy< mtSpOp<out_eT, T1, spop_type> >
   public:
   
   typedef          out_eT                          elem_type;
-  typedef typename T1::elem_type                   eT;
   typedef typename get_pod_type<elem_type>::result pod_type;
   typedef SpMat<out_eT>                            stored_type;
   
@@ -368,9 +423,9 @@ class SpProxy< mtSpOp<out_eT, T1, spop_type> >
   arma_inline elem_type operator[](const uword i)                    const { return Q[i];           }
   arma_inline elem_type at        (const uword row, const uword col) const { return Q.at(row, col); }
   
-  arma_inline const eT*    get_values()      const { return Q.values;      }
-  arma_inline const uword* get_row_indices() const { return Q.row_indices; }
-  arma_inline const uword* get_col_ptrs()    const { return Q.col_ptrs;    }
+  arma_inline const out_eT* get_values()      const { return Q.values;      }
+  arma_inline const uword*  get_row_indices() const { return Q.row_indices; }
+  arma_inline const uword*  get_col_ptrs()    const { return Q.col_ptrs;    }
   
   arma_inline const_iterator_type     begin()                            const { return Q.begin();            }
   arma_inline const_iterator_type     begin_col(const uword col_num)     const { return Q.begin_col(col_num); }

--- a/inst/include/armadillo_bits/SpRow_meat.hpp
+++ b/inst/include/armadillo_bits/SpRow_meat.hpp
@@ -234,6 +234,8 @@ SpRow<eT>::shed_cols(const uword in_col1, const uword in_col2)
     "SpRow::shed_cols(): indices out of bounds or incorrectly used"
     );
   
+  SpMat<eT>::sync_csc();
+  
   const uword diff = (in_col2 - in_col1 + 1);
 
   // This is doubleplus easy because we have all the column pointers stored.
@@ -293,6 +295,8 @@ SpRow<eT>::shed_cols(const uword in_col1, const uword in_col2)
 
   access::rw(SpMat<eT>::n_cols) -= diff;
   access::rw(SpMat<eT>::n_elem) -= diff;
+  
+  SpMat<eT>::invalidate_cache();
   }
 
 

--- a/inst/include/armadillo_bits/SpSubview_bones.hpp
+++ b/inst/include/armadillo_bits/SpSubview_bones.hpp
@@ -72,7 +72,7 @@ class SpSubview : public SpBase<eT, SpSubview<eT> >
   template<typename T1> inline const SpSubview& operator*=(const SpBase<eT, T1>& x);
   template<typename T1> inline const SpSubview& operator%=(const SpBase<eT, T1>& x);
   template<typename T1> inline const SpSubview& operator/=(const SpBase<eT, T1>& x);
-
+  
   /*
   inline static void extract(SpMat<eT>& out, const SpSubview& in);
 
@@ -89,20 +89,20 @@ class SpSubview : public SpBase<eT, SpSubview<eT> >
   inline void ones();
   inline void eye();
 
-  arma_hot inline SpValProxy<SpSubview<eT> > operator[](const uword i);
-  arma_hot inline eT                         operator[](const uword i) const;
+  arma_hot inline MapMat_svel<eT> operator[](const uword i);
+  arma_hot inline eT              operator[](const uword i) const;
 
-  arma_hot inline SpValProxy<SpSubview<eT> > operator()(const uword i);
-  arma_hot inline eT                         operator()(const uword i) const;
+  arma_hot inline MapMat_svel<eT> operator()(const uword i);
+  arma_hot inline eT              operator()(const uword i) const;
 
-  arma_hot inline SpValProxy<SpSubview<eT> > operator()(const uword in_row, const uword in_col);
-  arma_hot inline eT                         operator()(const uword in_row, const uword in_col) const;
+  arma_hot inline MapMat_svel<eT> operator()(const uword in_row, const uword in_col);
+  arma_hot inline eT              operator()(const uword in_row, const uword in_col) const;
 
-  arma_hot inline SpValProxy<SpSubview<eT> > at(const uword i);
-  arma_hot inline eT                         at(const uword i) const;
+  arma_hot inline MapMat_svel<eT> at(const uword i);
+  arma_hot inline eT              at(const uword i) const;
 
-  arma_hot inline SpValProxy<SpSubview<eT> > at(const uword in_row, const uword in_col);
-  arma_hot inline eT                         at(const uword in_row, const uword in_col) const;
+  arma_hot inline MapMat_svel<eT> at(const uword in_row, const uword in_col);
+  arma_hot inline eT              at(const uword in_row, const uword in_col) const;
 
   inline bool check_overlap(const SpSubview& x) const;
 
@@ -154,7 +154,7 @@ class SpSubview : public SpBase<eT, SpSubview<eT> >
     inline iterator_base(const SpSubview& in_M);
     inline iterator_base(const SpSubview& in_M, const uword col, const uword pos, const uword skip_pos);
 
-    inline eT operator*() const;
+    arma_inline eT operator*() const;
 
     // Don't hold location internally; call "dummy" methods to get that information.
     arma_inline uword row() const { return M.m.row_indices[internal_pos + skip_pos] - M.aux_row1; }

--- a/inst/include/armadillo_bits/SpSubview_iterators_meat.hpp
+++ b/inst/include/armadillo_bits/SpSubview_iterators_meat.hpp
@@ -49,7 +49,7 @@ SpSubview<eT>::iterator_base::iterator_base(const SpSubview<eT>& in_M, const uwo
 
 
 template<typename eT>
-inline
+arma_inline
 eT
 SpSubview<eT>::iterator_base::operator*() const
   {

--- a/inst/include/armadillo_bits/SpSubview_meat.hpp
+++ b/inst/include/armadillo_bits/SpSubview_meat.hpp
@@ -31,6 +31,8 @@ SpSubview<eT>::SpSubview(const SpMat<eT>& in_m, const uword in_row1, const uword
   {
   arma_extra_debug_sigprint();
   
+  m.sync_csc();
+  
   // There must be a O(1) way to do this
   uword lend     = m.col_ptrs[in_col1 + in_n_cols];
   uword lend_row = in_row1 + in_n_rows;
@@ -62,6 +64,8 @@ SpSubview<eT>::SpSubview(SpMat<eT>& in_m, const uword in_row1, const uword in_co
   , n_nonzero(0)
   {
   arma_extra_debug_sigprint();
+  
+  m.sync_csc();
   
   // There must be a O(1) way to do this
   uword lend     = m.col_ptrs[in_col1 + in_n_cols];
@@ -140,6 +144,9 @@ SpSubview<eT>::operator*=(const eT val)
   {
   arma_extra_debug_sigprint();
   
+  m.sync_csc();
+  m.invalidate_cache();
+  
   const uword lstart_row = aux_row1;
   const uword lend_row   = aux_row1 + n_rows;
   
@@ -148,6 +155,8 @@ SpSubview<eT>::operator*=(const eT val)
   
   const uword* m_row_indices = m.row_indices;
         eT*    m_values      = access::rwp(m.values);
+  
+  bool has_zero = false;
   
   for(uword c = lstart_col; c < lend_col; ++c)
     {
@@ -160,18 +169,25 @@ SpSubview<eT>::operator*=(const eT val)
       
       if( (m_row_indices_r >= lstart_row) && (m_row_indices_r < lend_row) )
         {
-        m_values[r] *= val;
+        eT& m_values_r = m_values[r];
+        
+        m_values_r *= val;
+        
+        if(m_values_r == eT(0))  { has_zero = true; }
         }
       }
     }
   
-  const uword old_m_n_nonzero = m.n_nonzero;
-  
-  access::rw(m).remove_zeros();
-  
-  if(m.n_nonzero != old_m_n_nonzero)
+  if(has_zero)
     {
-    access::rw(n_nonzero) = n_nonzero - (old_m_n_nonzero - m.n_nonzero); 
+    const uword old_m_n_nonzero = m.n_nonzero;
+    
+    access::rw(m).remove_zeros();
+    
+    if(m.n_nonzero != old_m_n_nonzero)
+      {
+      access::rw(n_nonzero) = n_nonzero - (old_m_n_nonzero - m.n_nonzero); 
+      }
     }
   
   return *this;
@@ -188,6 +204,9 @@ SpSubview<eT>::operator/=(const eT val)
   
   arma_debug_check( (val == eT(0)), "element-wise division: division by zero" );
   
+  m.sync_csc();
+  m.invalidate_cache();
+  
   const uword lstart_row = aux_row1;
   const uword lend_row   = aux_row1 + n_rows;
   
@@ -196,6 +215,8 @@ SpSubview<eT>::operator/=(const eT val)
   
   const uword* m_row_indices = m.row_indices;
         eT*    m_values      = access::rwp(m.values);
+  
+  bool has_zero = false;
   
   for(uword c = lstart_col; c < lend_col; ++c)
     {
@@ -208,18 +229,25 @@ SpSubview<eT>::operator/=(const eT val)
       
       if( (m_row_indices_r >= lstart_row) && (m_row_indices_r < lend_row) )
         {
-        m_values[r] /= val;
+        eT& m_values_r = m_values[r];
+        
+        m_values_r /= val;
+        
+        if(m_values_r == eT(0))  { has_zero = true; }
         }
       }
     }
   
-  const uword old_m_n_nonzero = m.n_nonzero;
-  
-  access::rw(m).remove_zeros();
-  
-  if(m.n_nonzero != old_m_n_nonzero)
+  if(has_zero)
     {
-    access::rw(n_nonzero) = n_nonzero - (old_m_n_nonzero - m.n_nonzero); 
+    const uword old_m_n_nonzero = m.n_nonzero;
+    
+    access::rw(m).remove_zeros();
+    
+    if(m.n_nonzero != old_m_n_nonzero)
+      {
+      access::rw(n_nonzero) = n_nonzero - (old_m_n_nonzero - m.n_nonzero); 
+      }
     }
   
   return *this;
@@ -819,6 +847,9 @@ SpSubview<eT>::replace(const eT old_val, const eT new_val)
     return;
     }
   
+  m.sync_csc();
+  m.invalidate_cache();
+  
   const uword lstart_row = aux_row1;
   const uword lend_row   = aux_row1 + n_rows;
   
@@ -940,7 +971,7 @@ SpSubview<eT>::eye()
 template<typename eT>
 arma_hot
 inline
-SpValProxy<SpSubview<eT> >
+MapMat_svel<eT>
 SpSubview<eT>::operator[](const uword i)
   {
   const uword lrow = i % n_rows;
@@ -968,7 +999,7 @@ SpSubview<eT>::operator[](const uword i) const
 template<typename eT>
 arma_hot
 inline
-SpValProxy< SpSubview<eT> >
+MapMat_svel<eT>
 SpSubview<eT>::operator()(const uword i)
   {
   arma_debug_check( (i >= n_elem), "SpSubview::operator(): index out of bounds");
@@ -1000,7 +1031,7 @@ SpSubview<eT>::operator()(const uword i) const
 template<typename eT>
 arma_hot
 inline
-SpValProxy< SpSubview<eT> >
+MapMat_svel<eT>
 SpSubview<eT>::operator()(const uword in_row, const uword in_col)
   {
   arma_debug_check( (in_row >= n_rows) || (in_col >= n_cols), "SpSubview::operator(): index out of bounds");
@@ -1026,7 +1057,7 @@ SpSubview<eT>::operator()(const uword in_row, const uword in_col) const
 template<typename eT>
 arma_hot
 inline
-SpValProxy< SpSubview<eT> >
+MapMat_svel<eT>
 SpSubview<eT>::at(const uword i)
   {
   const uword lrow = i % n_rows;
@@ -1054,30 +1085,12 @@ SpSubview<eT>::at(const uword i) const
 template<typename eT>
 arma_hot
 inline
-SpValProxy< SpSubview<eT> >
+MapMat_svel<eT>
 SpSubview<eT>::at(const uword in_row, const uword in_col)
   {
-  const uword colptr      = m.col_ptrs[in_col + aux_col1];
-  const uword next_colptr = m.col_ptrs[in_col + aux_col1 + 1];
-
-  // Step through the row indices to see if our element exists.
-  for(uword i = colptr; i < next_colptr; ++i)
-    {
-    // First check that we have not stepped past it.
-    if((in_row + aux_row1) < m.row_indices[i])
-      {
-      return SpValProxy<SpSubview<eT> >(in_row, in_col, *this); // Proxy for a zero value.
-      }
-
-    // Now check if we are at the correct place.
-    if((in_row + aux_row1) == m.row_indices[i]) // If we are, return a reference to the value.
-      {
-      return SpValProxy<SpSubview<eT> >(in_row, in_col, *this, &access::rw(m.values[i]));
-      }
-    }
-
-  // We did not find it, so it does not exist.
-  return SpValProxy<SpSubview<eT> >(in_row, in_col, *this);
+  m.sync_cache();
+  
+  return m.cache.svel(aux_row1 + in_row, aux_col1 + in_col, m.sync_state, access::rw(m.n_nonzero), access::rw(n_nonzero));
   }
 
 
@@ -1452,8 +1465,8 @@ SpSubview<eT>::swap_rows(const uword in_row1, const uword in_row2)
 
   for(uword c = lstart_col; c < lend_col; ++c)
     {
-    eT val = m.at(in_row1 + aux_row1, c);
-    access::rw(m).at(in_row2 + aux_row1, c) = m.at(in_row1 + aux_row1, c);
+    const eT val = access::rw(m).at(in_row1 + aux_row1, c);
+    access::rw(m).at(in_row2 + aux_row1, c) = eT( access::rw(m).at(in_row1 + aux_row1, c) );
     access::rw(m).at(in_row1 + aux_row1, c) = val;
     }
   }
@@ -1474,8 +1487,8 @@ SpSubview<eT>::swap_cols(const uword in_col1, const uword in_col2)
 
   for(uword r = lstart_row; r < lend_row; ++r)
     {
-    eT val = m.at(r, in_col1 + aux_col1);
-    access::rw(m).at(r, in_col1 + aux_col1) = m.at(r, in_col2 + aux_col1);
+    const eT val = access::rw(m).at(r, in_col1 + aux_col1);
+    access::rw(m).at(r, in_col1 + aux_col1) = eT( access::rw(m).at(r, in_col2 + aux_col1) );
     access::rw(m).at(r, in_col2 + aux_col1) = val;
     }
   }
@@ -1497,6 +1510,8 @@ inline
 typename SpSubview<eT>::const_iterator
 SpSubview<eT>::begin() const
   {
+  m.sync_csc();
+  
   return const_iterator(*this);
   }
 
@@ -1507,6 +1522,8 @@ inline
 typename SpSubview<eT>::iterator
 SpSubview<eT>::begin_col(const uword col_num)
   {
+  m.sync_csc();
+  
   return iterator(*this, 0, col_num);
   }
 
@@ -1516,6 +1533,8 @@ inline
 typename SpSubview<eT>::const_iterator
 SpSubview<eT>::begin_col(const uword col_num) const
   {
+  m.sync_csc();
+  
   return const_iterator(*this, 0, col_num);
   }
 
@@ -1526,6 +1545,8 @@ inline
 typename SpSubview<eT>::row_iterator
 SpSubview<eT>::begin_row(const uword row_num)
   {
+  m.sync_csc();
+  
   return row_iterator(*this, row_num, 0);
   }
 
@@ -1536,6 +1557,8 @@ inline
 typename SpSubview<eT>::const_row_iterator
 SpSubview<eT>::begin_row(const uword row_num) const
   {
+  m.sync_csc();
+  
   return const_row_iterator(*this, row_num, 0);
   }
 
@@ -1546,6 +1569,8 @@ inline
 typename SpSubview<eT>::iterator
 SpSubview<eT>::end()
   {
+  m.sync_csc();
+  
   return iterator(*this, 0, n_cols, n_nonzero, m.n_nonzero - n_nonzero);
   }
 
@@ -1556,6 +1581,8 @@ inline
 typename SpSubview<eT>::const_iterator
 SpSubview<eT>::end() const
   {
+  m.sync_csc();
+  
   return const_iterator(*this, 0, n_cols, n_nonzero, m.n_nonzero - n_nonzero);
   }
 
@@ -1566,6 +1593,8 @@ inline
 typename SpSubview<eT>::row_iterator
 SpSubview<eT>::end_row()
   {
+  m.sync_csc();
+  
   return row_iterator(*this, n_nonzero);
   }
 
@@ -1576,6 +1605,8 @@ inline
 typename SpSubview<eT>::const_row_iterator
 SpSubview<eT>::end_row() const
   {
+  m.sync_csc();
+  
   return const_row_iterator(*this, n_nonzero);
   }
 
@@ -1586,6 +1617,8 @@ inline
 typename SpSubview<eT>::row_iterator
 SpSubview<eT>::end_row(const uword row_num)
   {
+  m.sync_csc();
+  
   return row_iterator(*this, row_num + 1, 0);
   }
 
@@ -1596,6 +1629,8 @@ inline
 typename SpSubview<eT>::const_row_iterator
 SpSubview<eT>::end_row(const uword row_num) const
   {
+  m.sync_csc();
+  
   return const_row_iterator(*this, row_num + 1, 0);
   }
 

--- a/inst/include/armadillo_bits/SpValProxy_bones.hpp
+++ b/inst/include/armadillo_bits/SpValProxy_bones.hpp
@@ -68,12 +68,12 @@ class SpValProxy
   // Deletes the element if it is zero.  Does not check if val_ptr == NULL!
   arma_inline arma_hot void check_zero();
   
-  uword row;
-  uword col;
+  arma_aligned const uword row;
+  arma_aligned const uword col;
   
-  eT* val_ptr;
+  arma_aligned eT* val_ptr;
   
-  T1& parent; // We will call this object if we need to insert or delete an element.
+  arma_aligned T1& parent; // We will call this object if we need to insert or delete an element.
   };
 
 

--- a/inst/include/armadillo_bits/arma_forward.hpp
+++ b/inst/include/armadillo_bits/arma_forward.hpp
@@ -50,6 +50,11 @@ template<typename eT> class SpSubview;
 template<typename eT> class diagview;
 template<typename eT> class spdiagview;
 
+template<typename eT> class MapMat;
+template<typename eT> class MapMat_val;
+template<typename eT> class MapMat_elem;
+template<typename eT> class MapMat_svel;
+
 template<typename eT, typename T1>              class subview_elem1;
 template<typename eT, typename T1, typename T2> class subview_elem2;
 
@@ -264,6 +269,24 @@ enum file_type
   hdf5_binary,        //!< Open binary format, not specific to Armadillo, which can store arbitrary data
   hdf5_binary_trans,  //!< as per hdf5_binary, but save/load the data with columns transposed to rows
   coord_ascii         //!< simple co-ordinate format for sparse matrices
+  };
+
+
+struct hdf5_name
+  {
+  const std::string filename;
+  const std::string dsname;
+  
+  inline
+  hdf5_name(const std::string& in_filename)
+    : filename(in_filename)
+    {}
+  
+  inline
+  hdf5_name(const std::string& in_filename, const std::string& in_dsname)
+    : filename(in_filename)
+    , dsname  (in_dsname  )
+    {}
   };
 
 

--- a/inst/include/armadillo_bits/auxlib_meat.hpp
+++ b/inst/include/armadillo_bits/auxlib_meat.hpp
@@ -285,7 +285,7 @@ auxlib::inv_inplace_lapack(Mat<eT>& out)
     }
   #else
     {
-    out.reset();
+    out.soft_reset();
     arma_stop_logic_error("inv(): use of ATLAS or LAPACK must be enabled");
     return false;
     }

--- a/inst/include/armadillo_bits/config.hpp
+++ b/inst/include/armadillo_bits/config.hpp
@@ -159,9 +159,30 @@
 //// This is mainly useful for debugging of the library.
 
 
-#if !defined(ARMA_DEFAULT_OSTREAM)
-  #define ARMA_DEFAULT_OSTREAM std::cout
+#if defined(ARMA_DEFAULT_OSTREAM)
+  #pragma message ("WARNING: support for ARMA_DEFAULT_OSTREAM is deprecated and will be removed;")
+  #pragma message ("WARNING: use ARMA_COUT_STREAM and ARMA_CERR_STREAM instead")
 #endif
+
+
+#if !defined(ARMA_COUT_STREAM)
+  #if defined(ARMA_DEFAULT_OSTREAM)
+    // for compatibility with earlier versions of Armadillo
+    #define ARMA_COUT_STREAM ARMA_DEFAULT_OSTREAM
+  #else
+    #define ARMA_COUT_STREAM std::cout
+  #endif
+#endif
+
+#if !defined(ARMA_CERR_STREAM)
+  #if defined(ARMA_DEFAULT_OSTREAM)
+    // for compatibility with earlier versions of Armadillo
+    #define ARMA_CERR_STREAM ARMA_DEFAULT_OSTREAM
+  #else
+    #define ARMA_CERR_STREAM std::cerr
+  #endif
+#endif
+
 
 #if !defined(ARMA_PRINT_ERRORS)
 #define ARMA_PRINT_ERRORS
@@ -230,6 +251,7 @@
 
 #if defined(ARMA_DONT_USE_HDF5)
   #undef ARMA_USE_HDF5
+  #undef ARMA_USE_HDF5_ALT
 #endif
 
 #if defined(ARMA_DONT_PRINT_ERRORS)

--- a/inst/include/armadillo_bits/config.hpp.cmake
+++ b/inst/include/armadillo_bits/config.hpp.cmake
@@ -159,9 +159,30 @@
 //// This is mainly useful for debugging of the library.
 
 
-#if !defined(ARMA_DEFAULT_OSTREAM)
-  #define ARMA_DEFAULT_OSTREAM std::cout
+#if defined(ARMA_DEFAULT_OSTREAM)
+  #pragma message ("WARNING: support for ARMA_DEFAULT_OSTREAM is deprecated and will be removed;")
+  #pragma message ("WARNING: use ARMA_COUT_STREAM and ARMA_CERR_STREAM instead")
 #endif
+
+
+#if !defined(ARMA_COUT_STREAM)
+  #if defined(ARMA_DEFAULT_OSTREAM)
+    // for compatibility with earlier versions of Armadillo
+    #define ARMA_COUT_STREAM ARMA_DEFAULT_OSTREAM
+  #else
+    #define ARMA_COUT_STREAM std::cout
+  #endif
+#endif
+
+#if !defined(ARMA_CERR_STREAM)
+  #if defined(ARMA_DEFAULT_OSTREAM)
+    // for compatibility with earlier versions of Armadillo
+    #define ARMA_CERR_STREAM ARMA_DEFAULT_OSTREAM
+  #else
+    #define ARMA_CERR_STREAM std::cerr
+  #endif
+#endif
+
 
 #if !defined(ARMA_PRINT_ERRORS)
 #define ARMA_PRINT_ERRORS
@@ -230,6 +251,7 @@
 
 #if defined(ARMA_DONT_USE_HDF5)
   #undef ARMA_USE_HDF5
+  #undef ARMA_USE_HDF5_ALT
 #endif
 
 #if defined(ARMA_DONT_PRINT_ERRORS)

--- a/inst/include/armadillo_bits/debug.hpp
+++ b/inst/include/armadillo_bits/debug.hpp
@@ -22,13 +22,13 @@
 template<typename T>
 inline
 std::ostream&
-arma_stream_err1(std::ostream* user_stream)
+arma_cout_stream(std::ostream* user_stream)
   {
-  static std::ostream* stream_err1 = &(ARMA_DEFAULT_OSTREAM);
+  static std::ostream* cout_stream = &(ARMA_COUT_STREAM);
   
-  if(user_stream != NULL)  { stream_err1 = user_stream; }
+  if(user_stream != NULL)  { cout_stream = user_stream; }
   
-  return *stream_err1;
+  return (*cout_stream);
   }
 
 
@@ -36,54 +36,98 @@ arma_stream_err1(std::ostream* user_stream)
 template<typename T>
 inline
 std::ostream&
-arma_stream_err2(std::ostream* user_stream)
+arma_cerr_stream(std::ostream* user_stream)
   {
-  static std::ostream* stream_err2 = &(ARMA_DEFAULT_OSTREAM);
+  static std::ostream* cerr_stream = &(ARMA_CERR_STREAM);
   
-  if(user_stream != NULL)  { stream_err2 = user_stream; }
+  if(user_stream != NULL)  { cerr_stream = user_stream; }
   
-  return *stream_err2;
+  return (*cerr_stream);
   }
 
 
 
 inline
+void
+set_cout_stream(std::ostream& user_stream)
+  {
+  arma_cout_stream<char>(&user_stream);
+  }
+
+
+
+inline
+void
+set_cerr_stream(std::ostream& user_stream)
+  {
+  arma_cerr_stream<char>(&user_stream);
+  }
+
+
+
+inline
+std::ostream&
+get_cout_stream()
+  {
+  return arma_cout_stream<char>(NULL);
+  }
+
+
+
+inline
+std::ostream&
+get_cerr_stream()
+  {
+  return arma_cerr_stream<char>(NULL);
+  }
+
+
+
+//! do not use this function - it's deprecated and will be removed
+inline
+arma_deprecated
 void
 set_stream_err1(std::ostream& user_stream)
   {
-  arma_stream_err1<char>(&user_stream);
+  set_cerr_stream(user_stream);
   }
 
 
 
+//! do not use this function - it's deprecated and will be removed
 inline
+arma_deprecated
 void
 set_stream_err2(std::ostream& user_stream)
   {
-  arma_stream_err2<char>(&user_stream);
+  set_cerr_stream(user_stream);
   }
 
 
 
+//! do not use this function - it's deprecated and will be removed
 inline
+arma_deprecated
 std::ostream&
 get_stream_err1()
   {
-  return arma_stream_err1<char>(NULL);
+  return get_cerr_stream();
   }
 
 
 
+//! do not use this function - it's deprecated and will be removed
 inline
+arma_deprecated
 std::ostream&
 get_stream_err2()
   {
-  return arma_stream_err2<char>(NULL);
+  return get_cerr_stream();
   }
 
 
 
-//! print a message to get_stream_err1() and throw logic_error exception
+//! print a message to get_cerr_stream() and throw logic_error exception
 template<typename T1>
 arma_cold
 arma_noinline
@@ -93,7 +137,7 @@ arma_stop_logic_error(const T1& x)
   {
   #if defined(ARMA_PRINT_ERRORS)
     {
-    get_stream_err1() << "\nerror: " << x << std::endl;
+    get_cerr_stream() << "\nerror: " << x << std::endl;
     }
   #endif
   
@@ -102,7 +146,7 @@ arma_stop_logic_error(const T1& x)
 
 
 
-//! print a message to get_stream_err2() and throw bad_alloc exception
+//! print a message to get_cerr_stream() and throw bad_alloc exception
 template<typename T1>
 arma_cold
 arma_noinline
@@ -112,7 +156,7 @@ arma_stop_bad_alloc(const T1& x)
   {
   #if defined(ARMA_PRINT_ERRORS)
     {
-    get_stream_err2() << "\nerror: " << x << std::endl;
+    get_cerr_stream() << "\nerror: " << x << std::endl;
     }
   #else
     {
@@ -125,7 +169,7 @@ arma_stop_bad_alloc(const T1& x)
 
 
 
-//! print a message to get_stream_err2() and throw runtime_error exception
+//! print a message to get_cerr_stream() and throw runtime_error exception
 template<typename T1>
 arma_cold
 arma_noinline
@@ -135,7 +179,7 @@ arma_stop_runtime_error(const T1& x)
   {
   #if defined(ARMA_PRINT_ERRORS)
     {
-    get_stream_err2() << "\nerror: " << x << std::endl;
+    get_cerr_stream() << "\nerror: " << x << std::endl;
     }
   #endif
   
@@ -153,7 +197,7 @@ inline
 void
 arma_print()
   {
-  get_stream_err1() << std::endl;
+  get_cerr_stream() << std::endl;
   }
 
 
@@ -164,7 +208,7 @@ static
 void
 arma_print(const T1& x)
   {
-  get_stream_err1() << x << std::endl;
+  get_cerr_stream() << x << std::endl;
   }
 
 
@@ -176,7 +220,7 @@ static
 void
 arma_print(const T1& x, const T2& y)
   {
-  get_stream_err1() << x << y << std::endl;
+  get_cerr_stream() << x << y << std::endl;
   }
 
 
@@ -188,7 +232,7 @@ static
 void
 arma_print(const T1& x, const T2& y, const T3& z)
   {
-  get_stream_err1() << x << y << z << std::endl;
+  get_cerr_stream() << x << y << z << std::endl;
   }
 
 
@@ -207,7 +251,7 @@ inline
 void
 arma_sigprint(const char* x)
   {
-  get_stream_err1() << "@ " << x;
+  get_cerr_stream() << "@ " << x;
   }
 
 
@@ -220,7 +264,7 @@ inline
 void
 arma_bktprint()
   {
-  get_stream_err1() << std::endl;
+  get_cerr_stream() << std::endl;
   }
 
 
@@ -229,7 +273,7 @@ inline
 void
 arma_bktprint(const T1& x)
   {
-  get_stream_err1() << " [" << x << ']' << std::endl;
+  get_cerr_stream() << " [" << x << ']' << std::endl;
   }
 
 
@@ -239,7 +283,7 @@ inline
 void
 arma_bktprint(const T1& x, const T2& y)
   {
-  get_stream_err1() << " [" << x << y << ']' << std::endl;
+  get_cerr_stream() << " [" << x << y << ']' << std::endl;
   }
 
 
@@ -254,7 +298,7 @@ inline
 void
 arma_thisprint(const void* this_ptr)
   {
-  get_stream_err1() << " [this = " << this_ptr << ']' << std::endl;
+  get_cerr_stream() << " [this = " << this_ptr << ']' << std::endl;
   }
 
 
@@ -273,7 +317,7 @@ arma_warn(const T1& x)
   {
   #if defined(ARMA_PRINT_ERRORS)
     {
-    get_stream_err2() << "\nwarning: " << x << '\n';
+    get_cerr_stream() << "\nwarning: " << x << '\n';
     }
   #else
     {
@@ -292,7 +336,7 @@ arma_warn(const T1& x, const T2& y)
   {
   #if defined(ARMA_PRINT_ERRORS)
     {
-    get_stream_err2() << "\nwarning: " << x << y << '\n';
+    get_cerr_stream() << "\nwarning: " << x << y << '\n';
     }
   #else
     {
@@ -312,7 +356,7 @@ arma_warn(const T1& x, const T2& y, const T3& z)
   {
   #if defined(ARMA_PRINT_ERRORS)
     {
-    get_stream_err2() << "\nwarning: " << x << y << z << '\n';
+    get_cerr_stream() << "\nwarning: " << x << y << z << '\n';
     }
   #else
     {
@@ -1265,7 +1309,7 @@ arma_assert_atlas_size(const T1& A, const T2& B)
         const bool  little_endian = (endian_test.b[0] == 1);
         const char* nickname      = ARMA_VERSION_NAME;
         
-        std::ostream& out = get_stream_err1();
+        std::ostream& out = get_cerr_stream();
         
         out << "@ ---" << '\n';
         out << "@ Armadillo "

--- a/inst/include/armadillo_bits/def_hdf5.hpp
+++ b/inst/include/armadillo_bits/def_hdf5.hpp
@@ -49,6 +49,9 @@
   #define arma_H5Fclose     H5Fclose
   #define arma_H5Fis_hdf5   H5Fis_hdf5
 
+  #define arma_H5Gcreate    H5Gcreate
+  #define arma_H5Gclose     H5Gclose
+
   #define arma_H5T_NATIVE_UCHAR   H5T_NATIVE_UCHAR
   #define arma_H5T_NATIVE_CHAR    H5T_NATIVE_CHAR
   #define arma_H5T_NATIVE_SHORT   H5T_NATIVE_SHORT
@@ -97,6 +100,9 @@ extern "C"
   hid_t  arma_H5Fcreate(const char* name, unsigned flags, hid_t fcpl_id, hid_t fapl_id);
   herr_t arma_H5Fclose(hid_t file_id);
   htri_t arma_H5Fis_hdf5(const char* name);
+
+  hid_t  arma_H5Gcreate(hid_t loc_id, const char* name, hid_t lcpl_id, hid_t gcpl_id, hid_t gapl_id);
+  herr_t arma_H5Gclose(hid_t group_id);
   
   // Wrapper variables that represent the hid_t values for the H5T_NATIVE_*
   // types.  Note that H5T_NATIVE_UCHAR itself is a macro that resolves to about

--- a/inst/include/armadillo_bits/diskio_bones.hpp
+++ b/inst/include/armadillo_bits/diskio_bones.hpp
@@ -50,7 +50,7 @@ class diskio
   template<typename eT> inline static bool save_arma_binary(const Mat<eT>&                x, const std::string& final_name);
   template<typename eT> inline static bool save_pgm_binary (const Mat<eT>&                x, const std::string& final_name);
   template<typename  T> inline static bool save_pgm_binary (const Mat< std::complex<T> >& x, const std::string& final_name);
-  template<typename eT> inline static bool save_hdf5_binary(const Mat<eT>&                x, const std::string& final_name);
+  template<typename eT> inline static bool save_hdf5_binary(const Mat<eT>&                x, const   hdf5_name& spec      );
   
   template<typename eT> inline static bool save_raw_ascii  (const Mat<eT>&                x, std::ostream& f);
   template<typename eT> inline static bool save_raw_binary (const Mat<eT>&                x, std::ostream& f);
@@ -72,7 +72,7 @@ class diskio
   template<typename eT> inline static bool load_arma_binary(Mat<eT>&                x, const std::string& name, std::string& err_msg);
   template<typename eT> inline static bool load_pgm_binary (Mat<eT>&                x, const std::string& name, std::string& err_msg);
   template<typename  T> inline static bool load_pgm_binary (Mat< std::complex<T> >& x, const std::string& name, std::string& err_msg);
-  template<typename eT> inline static bool load_hdf5_binary(Mat<eT>&                x, const std::string& name, std::string& err_msg);
+  template<typename eT> inline static bool load_hdf5_binary(Mat<eT>&                x, const   hdf5_name& spec, std::string& err_msg);
   template<typename eT> inline static bool load_auto_detect(Mat<eT>&                x, const std::string& name, std::string& err_msg);
   
   template<typename eT> inline static bool load_raw_ascii  (Mat<eT>&                x, std::istream& f,  std::string& err_msg);
@@ -118,7 +118,7 @@ class diskio
   template<typename eT> inline static bool save_raw_binary (const Cube<eT>& x, const std::string& name);
   template<typename eT> inline static bool save_arma_ascii (const Cube<eT>& x, const std::string& name);
   template<typename eT> inline static bool save_arma_binary(const Cube<eT>& x, const std::string& name);
-  template<typename eT> inline static bool save_hdf5_binary(const Cube<eT>& x, const std::string& name);
+  template<typename eT> inline static bool save_hdf5_binary(const Cube<eT>& x, const   hdf5_name& spec);
   
   template<typename eT> inline static bool save_raw_ascii  (const Cube<eT>& x, std::ostream& f);
   template<typename eT> inline static bool save_raw_binary (const Cube<eT>& x, std::ostream& f);
@@ -133,7 +133,7 @@ class diskio
   template<typename eT> inline static bool load_raw_binary (Cube<eT>& x, const std::string& name, std::string& err_msg);
   template<typename eT> inline static bool load_arma_ascii (Cube<eT>& x, const std::string& name, std::string& err_msg);
   template<typename eT> inline static bool load_arma_binary(Cube<eT>& x, const std::string& name, std::string& err_msg);
-  template<typename eT> inline static bool load_hdf5_binary(Cube<eT>& x, const std::string& name, std::string& err_msg);
+  template<typename eT> inline static bool load_hdf5_binary(Cube<eT>& x, const   hdf5_name& spec, std::string& err_msg);
   template<typename eT> inline static bool load_auto_detect(Cube<eT>& x, const std::string& name, std::string& err_msg);
   
   template<typename eT> inline static bool load_raw_ascii  (Cube<eT>& x, std::istream& f, std::string& err_msg);

--- a/inst/include/armadillo_bits/diskio_meat.hpp
+++ b/inst/include/armadillo_bits/diskio_meat.hpp
@@ -799,6 +799,7 @@ diskio::save_raw_ascii(const Mat<eT>& x, std::ostream& f)
   
   if(is_real<eT>::value)
     {
+    f.unsetf(ios::fixed);
     f.setf(ios::scientific);
     f.precision(14);
     cell_width = 22;
@@ -806,6 +807,7 @@ diskio::save_raw_ascii(const Mat<eT>& x, std::ostream& f)
   
   if(is_cx<eT>::value)
     {
+    f.unsetf(ios::fixed);
     f.setf(ios::scientific);
     f.precision(14);
     }
@@ -929,6 +931,7 @@ diskio::save_arma_ascii(const Mat<eT>& x, std::ostream& f)
   
   if(is_real<eT>::value)
     {
+    f.unsetf(ios::fixed);
     f.setf(ios::scientific);
     f.precision(14);
     cell_width = 22;
@@ -936,6 +939,7 @@ diskio::save_arma_ascii(const Mat<eT>& x, std::ostream& f)
   
   if(is_cx<eT>::value)
     {
+    f.unsetf(ios::fixed);
     f.setf(ios::scientific);
     f.precision(14);
     }
@@ -1010,6 +1014,7 @@ diskio::save_csv_ascii(const Mat<eT>& x, std::ostream& f)
   
   if( (is_float<eT>::value) || (is_double<eT>::value) )
     {
+    f.unsetf(ios::fixed);
     f.setf(ios::scientific);
     f.precision(14);
     }
@@ -1052,6 +1057,7 @@ diskio::save_csv_ascii(const Mat< std::complex<T> >& x, std::ostream& f)
   
   if( (is_float<T>::value) || (is_double<T>::value) )
     {
+    f.unsetf(ios::fixed);
     f.setf(ios::scientific);
     f.precision(14);
     }
@@ -1246,7 +1252,7 @@ diskio::save_pgm_binary(const Mat< std::complex<T> >& x, std::ostream& f)
 template<typename eT>
 inline 
 bool 
-diskio::save_hdf5_binary(const Mat<eT>& x, const std::string& final_name)
+diskio::save_hdf5_binary(const Mat<eT>& x, const hdf5_name& spec)
   {
   arma_extra_debug_sigprint();
   
@@ -1261,9 +1267,9 @@ diskio::save_hdf5_binary(const Mat<eT>& x, const std::string& final_name)
     
     bool save_okay = false;
     
-    const std::string tmp_name = diskio::gen_tmp_name(final_name);
+    const std::string tmp_name = diskio::gen_tmp_name(spec.filename);
     
-    // Set up the file according to HDF5's preferences  
+    // Set up the file according to HDF5's preferences
     hid_t file = arma_H5Fcreate(tmp_name.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
     
     // We need to create a dataset, datatype, and dataspace
@@ -1277,10 +1283,28 @@ diskio::save_hdf5_binary(const Mat<eT>& x, const std::string& final_name)
     // If this returned something invalid, well, it's time to crash.
     arma_check(datatype == -1, "Mat::save(): unknown datatype for HDF5");
     
-    // MATLAB forces the users to specify a name at save time for HDF5; Octave
-    // will use the default of 'dataset' unless otherwise specified, so we will
-    // use that.
-    hid_t dataset = arma_H5Dcreate(file, "dataset", datatype, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    // MATLAB forces the users to specify a name at save time for HDF5;
+    // Octave will use the default of 'dataset' unless otherwise specified.
+    // If the user hasn't specified a dataset name, we will use 'dataset'
+    // We may have to split out the group name from the dataset name.
+    std::vector<hid_t> groups;
+    std::string full_name = spec.dsname;
+    size_t loc;
+    while ((loc = full_name.find("/")) != std::string::npos)
+      {
+      // Create another group...
+      if (loc != 0) // Ignore the first /, if there is a leading /.
+        {
+        hid_t gid = arma_H5Gcreate((groups.size() == 0) ? file : groups[groups.size() - 1], full_name.substr(0, loc).c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+        groups.push_back(gid);
+        }
+
+      full_name = full_name.substr(loc + 1);
+      }
+    
+    const std::string dataset_name = (full_name.empty() == false) ? full_name : std::string("dataset");
+
+    hid_t dataset = arma_H5Dcreate(groups.size() == 0 ? file : groups[groups.size() - 1], dataset_name.c_str(), datatype, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     
     // H5Dwrite does not make a distinction between row-major and column-major;
     // it just writes the memory.  MATLAB and Octave store HDF5 matrices as
@@ -1292,16 +1316,17 @@ diskio::save_hdf5_binary(const Mat<eT>& x, const std::string& final_name)
     arma_H5Dclose(dataset);
     arma_H5Tclose(datatype);
     arma_H5Sclose(dataspace);
+    for (size_t i = 0; i < groups.size(); ++i)  { arma_H5Gclose(groups[i]); }
     arma_H5Fclose(file);
     
-    if(save_okay == true) { save_okay = diskio::safe_rename(tmp_name, final_name); }
+    if(save_okay == true) { save_okay = diskio::safe_rename(tmp_name, spec.filename); }
     
     return save_okay;
     }
   #else
     {
     arma_ignore(x);
-    arma_ignore(final_name);
+    arma_ignore(spec);
     
     arma_stop_logic_error("Mat::save(): use of HDF5 needs to be enabled");
     
@@ -2284,13 +2309,12 @@ diskio::load_pgm_binary(Mat< std::complex<T> >& x, std::istream& is, std::string
 template<typename eT>
 inline
 bool
-diskio::load_hdf5_binary(Mat<eT>& x, const std::string& name, std::string& err_msg)
+diskio::load_hdf5_binary(Mat<eT>& x, const hdf5_name& spec, std::string& err_msg)
   {
   arma_extra_debug_sigprint();
   
   #if defined(ARMA_USE_HDF5)
     {
-
     // These may be necessary to store the error handler (if we need to).
     herr_t (*old_func)(hid_t, void*);
     void *old_client_data;
@@ -2307,19 +2331,31 @@ diskio::load_hdf5_binary(Mat<eT>& x, const std::string& name, std::string& err_m
 
     bool load_okay = false;
     
-    hid_t fid = arma_H5Fopen(name.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+    hid_t fid = arma_H5Fopen(spec.filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
     
     if(fid >= 0)
       {
       // MATLAB HDF5 dataset names are user-specified;
       // Octave tends to store the datasets in a group, with the actual dataset being referred to as "value".
-      // So we will search for "dataset" and "value", and if those are not found we will take the first dataset we do find.
-      std::vector<std::string> searchNames;
-      searchNames.push_back("dataset");
-      searchNames.push_back("value");
+      // If the user hasn't specified a dataset, we will search for "dataset" and "value",
+      // and if those are not found we will take the first dataset we do find.
       
-      hid_t dataset = hdf5_misc::search_hdf5_file(searchNames, fid, 2, false);
-
+      std::vector<std::string> searchNames;
+      
+      const bool exact = (spec.dsname.empty() == false);
+      
+      if(exact)
+        {
+        searchNames.push_back(spec.dsname);
+        }
+      else
+        {
+        searchNames.push_back("dataset");
+        searchNames.push_back("value"  );
+        }
+      
+      hid_t dataset = hdf5_misc::search_hdf5_file(searchNames, fid, 2, exact);
+      
       if(dataset >= 0)
         {
         hid_t filespace = arma_H5Dget_space(dataset);
@@ -2405,7 +2441,7 @@ diskio::load_hdf5_binary(Mat<eT>& x, const std::string& name, std::string& err_m
   #else
     {
     arma_ignore(x);
-    arma_ignore(name);
+    arma_ignore(spec);
     arma_ignore(err_msg);
 
     arma_stop_logic_error("Mat::load(): use of HDF5 needs to be enabled");
@@ -2561,22 +2597,19 @@ diskio::save_coord_ascii(const SpMat<eT>& x, std::ostream& f)
   
   const ios::fmtflags orig_flags = f.flags();
   
+  if( (is_float<eT>::value) || (is_double<eT>::value) )
+    {
+    f.unsetf(ios::fixed);
+    f.setf(ios::scientific);
+    f.precision(14);
+    }
+    
   typename SpMat<eT>::const_iterator iter     = x.begin();
   typename SpMat<eT>::const_iterator iter_end = x.end();
   
   for(; iter != iter_end; ++iter)
     {
-    f.setf(ios::fixed);
-    
-    f << iter.row() << ' ' << iter.col() << ' ';
-    
-    if( (is_float<eT>::value) || (is_double<eT>::value) )
-      {
-      f.setf(ios::scientific);
-      f.precision(14);
-      }
-    
-    f << (*iter) << '\n';
+    f << iter.row() << ' ' << iter.col() << ' ' << (*iter) << '\n';
     }
   
   
@@ -2588,8 +2621,6 @@ diskio::save_coord_ascii(const SpMat<eT>& x, std::ostream& f)
     
     if( x.at(max_row, max_col) == eT(0) )
       {
-      f.setf(ios::fixed);
-      
       f << max_row << ' ' << max_col << " 0\n";
       }
     }
@@ -2611,28 +2642,25 @@ diskio::save_coord_ascii(const SpMat< std::complex<T> >& x, std::ostream& f)
   {
   arma_extra_debug_sigprint();
   
+  typedef typename std::complex<T> eT;
+  
   const ios::fmtflags orig_flags = f.flags();
   
-  typedef typename std::complex<T> eT;
+  if( (is_float<T>::value) || (is_double<T>::value) )
+    {
+    f.unsetf(ios::fixed);
+    f.setf(ios::scientific);
+    f.precision(14);
+    }
   
   typename SpMat<eT>::const_iterator iter     = x.begin();
   typename SpMat<eT>::const_iterator iter_end = x.end();
   
   for(; iter != iter_end; ++iter)
     {
-    f.setf(ios::fixed);
-    
-    f << iter.row() << ' ' << iter.col() << ' ';
-    
-    if( (is_float<T>::value) || (is_double<T>::value) )
-      {
-      f.setf(ios::scientific);
-      f.precision(14);
-      }
-    
     const eT val = (*iter);
     
-    f << val.real() << ' ' << val.imag() << '\n';
+    f << iter.row() << ' ' << iter.col() << ' ' << val.real() << ' ' << val.imag() << '\n';
     }
   
   // make sure it's possible to figure out the matrix size later
@@ -2643,8 +2671,6 @@ diskio::save_coord_ascii(const SpMat< std::complex<T> >& x, std::ostream& f)
     
     if( x.at(max_row, max_col) == eT(0) )
       {
-      f.setf(ios::fixed);
-      
       f << max_row << ' ' << max_col << " 0 0\n";
       }
     }
@@ -2743,19 +2769,15 @@ diskio::load_coord_ascii(SpMat<eT>& x, std::istream& f, std::string& err_msg)
   arma_extra_debug_sigprint();
   arma_ignore(err_msg);
   
-  // TODO: replace with more efficient implementation
-  
   bool load_okay = f.good();
   
   f.clear();
   const std::fstream::pos_type pos1 = f.tellg();
   
-  //
   // work out the size
   
   uword f_n_rows = 0;
   uword f_n_cols = 0;
-  uword f_n_nz   = 0;
   
   bool size_found = false;
   
@@ -2765,21 +2787,11 @@ diskio::load_coord_ascii(SpMat<eT>& x, std::istream& f, std::string& err_msg)
   std::stringstream line_stream;
   std::stringstream ss;
   
-  uword last_line_row = 0;
-  uword last_line_col = 0;
-  
-  bool first_line   = true;
-  bool weird_format = false;
-  
-  
   while( (f.good() == true) && (load_okay == true) )
     {
     std::getline(f, line_string);
     
-    if(line_string.size() == 0)
-      {
-      break;
-      }
+    if(line_string.size() == 0)  { break; }
     
     line_stream.clear();
     line_stream.str(line_string);
@@ -2791,105 +2803,33 @@ diskio::load_coord_ascii(SpMat<eT>& x, std::istream& f, std::string& err_msg)
     
     line_stream >> line_row;
     
-    if(line_stream.good() == false)
-      {
-      load_okay = false;
-      break;
-      }
+    if(line_stream.good() == false)  { load_okay = false; break; }
     
     line_stream >> line_col;
     
     size_found = true;
     
-    if(f_n_rows < line_row)  f_n_rows = line_row;
-    if(f_n_cols < line_col)  f_n_cols = line_col;
-    
-    if(first_line == true)
-      {
-      first_line = false;
-      }
-    else
-      {
-      if( (line_col < last_line_col) || ((line_row <= last_line_row) && (line_col <= last_line_col)) )
-        {
-        weird_format = true;
-        }
-      }
-    
-    last_line_row = line_row;
-    last_line_col = line_col;
-    
-    
-    if(line_stream.good() == true)
-      {
-      eT final_val = eT(0);
-      
-      line_stream >> token;
-      
-      if(line_stream.fail() == false)
-        {
-        eT val = eT(0);
-        
-        ss.clear();
-        ss.str(token);
-        
-        ss >> val;
-        
-        if(ss.fail() == false)
-          {
-          final_val = val;
-          }
-        else
-          {
-          val = eT(0);
-          
-          const bool success = diskio::convert_naninf( val, token );
-          
-          if(success == true)
-            {
-            final_val = val;
-            }
-          }
-        }
-      
-      if(final_val != eT(0))
-        {
-        ++f_n_nz;
-        }
-      }
+    if(f_n_rows < line_row)  { f_n_rows = line_row; }
+    if(f_n_cols < line_col)  { f_n_cols = line_col; }
     }
   
   
-  if(size_found == true)
-    {
-    // take into account that indices start at 0
-    f_n_rows++;
-    f_n_cols++;
-    }
+  // take into account that indices start at 0
+  if(size_found)  { ++f_n_rows;  ++f_n_cols; }
   
   
-  if(load_okay == true)
+  if(load_okay)
     {
     f.clear();
     f.seekg(pos1);
     
-    x.set_size(f_n_rows, f_n_cols);
+    MapMat<eT> tmp(f_n_rows, f_n_cols);
     
-    if(weird_format == false)
-      {
-      x.mem_resize(f_n_nz);
-      }
-    
-    uword pos = 0;
-    
-    while(f.good() == true)
+    while(f.good())
       {
       std::getline(f, line_string);
       
-      if(line_string.size() == 0)
-        {
-        break;
-        }
+      if(line_string.size() == 0)  { break; }
       
       line_stream.clear();
       line_stream.str(line_string);
@@ -2923,38 +2863,14 @@ diskio::load_coord_ascii(SpMat<eT>& x, std::istream& f, std::string& err_msg)
           
           const bool success = diskio::convert_naninf( val, token );
           
-          if(success == true)
-            {
-            final_val = val;
-            }
+          if(success)  { final_val = val; }
           }
         }
       
-      
-      if(final_val != eT(0))
-        {
-        if(weird_format == false)
-          {
-          access::rw(x.row_indices[pos]) = line_row;
-          access::rw(x.values[pos])      = final_val;
-          ++access::rw(x.col_ptrs[line_col + 1]);
-          
-          ++pos;
-          }
-        else
-          {
-          x.at(line_row,line_col) = final_val;
-          }
-        }
+      if(final_val != eT(0))  { tmp(line_row,line_col) = final_val; }
       }
     
-    if(weird_format == false)
-      {
-      for(uword c = 1; c <= f_n_cols; ++c)
-        {
-        access::rw(x.col_ptrs[c]) += x.col_ptrs[c - 1];
-        }
-      }
+    x = tmp;
     }
   
   return load_okay;
@@ -2970,19 +2886,15 @@ diskio::load_coord_ascii(SpMat< std::complex<T> >& x, std::istream& f, std::stri
   arma_extra_debug_sigprint();
   arma_ignore(err_msg);
   
-  // TODO: replace with more efficient implementation
-  
   bool load_okay = f.good();
   
   f.clear();
   const std::fstream::pos_type pos1 = f.tellg();
   
-  //
   // work out the size
   
   uword f_n_rows = 0;
   uword f_n_cols = 0;
-  uword f_n_nz   = 0;
   
   bool size_found = false;
   
@@ -2993,20 +2905,11 @@ diskio::load_coord_ascii(SpMat< std::complex<T> >& x, std::istream& f, std::stri
   std::stringstream line_stream;
   std::stringstream ss;
   
-  uword last_line_row = 0;
-  uword last_line_col = 0;
-  
-  bool first_line   = true;
-  bool weird_format = false;
-  
   while( (f.good() == true) && (load_okay == true) )
     {
     std::getline(f, line_string);
     
-    if(line_string.size() == 0)
-      {
-      break;
-      }
+    if(line_string.size() == 0)  { break; }
     
     line_stream.clear();
     line_stream.str(line_string);
@@ -3018,11 +2921,7 @@ diskio::load_coord_ascii(SpMat< std::complex<T> >& x, std::istream& f, std::stri
     
     line_stream >> line_row;
     
-    if(line_stream.good() == false)
-      {
-      load_okay = false;
-      break;
-      }
+    if(line_stream.good() == false)  { load_okay = false; break; }
     
     line_stream >> line_col;
     
@@ -3030,119 +2929,21 @@ diskio::load_coord_ascii(SpMat< std::complex<T> >& x, std::istream& f, std::stri
     
     if(f_n_rows < line_row)  f_n_rows = line_row;
     if(f_n_cols < line_col)  f_n_cols = line_col;
-    
-    
-    if(first_line == true)
-      {
-      first_line = false;
-      }
-    else
-      {
-      if( (line_col < last_line_col) || ((line_row <= last_line_row) && (line_col <= last_line_col)) )
-        {
-        weird_format = true;
-        }
-      }
-    
-    last_line_row = line_row;
-    last_line_col = line_col;
-    
-    
-    if(line_stream.good() == true)
-      {
-      T final_val_real = T(0);
-      T final_val_imag = T(0);
-      
-      
-      line_stream >> token_real;
-      
-      if(line_stream.fail() == false)
-        {
-        T val_real = T(0);
-        
-        ss.clear();
-        ss.str(token_real);
-        
-        ss >> val_real;
-        
-        if(ss.fail() == false)
-          {
-          final_val_real = val_real;
-          }
-        else
-          {
-          val_real = T(0);
-          
-          const bool success = diskio::convert_naninf( val_real, token_real );
-          
-          if(success == true)
-            {
-            final_val_real = val_real;
-            }
-          }
-        }
-      
-      
-      line_stream >> token_imag;
-      
-      if(line_stream.fail() == false)
-        {
-        T val_imag = T(0);
-        
-        ss.clear();
-        ss.str(token_imag);
-        
-        ss >> val_imag;
-        
-        if(ss.fail() == false)
-          {
-          final_val_imag = val_imag;
-          }
-        else
-          {
-          val_imag = T(0);
-          
-          const bool success = diskio::convert_naninf( val_imag, token_imag );
-          
-          if(success == true)
-            {
-            final_val_imag = val_imag;
-            }
-          }
-        }
-      
-      
-      if( (final_val_real != T(0)) || (final_val_imag != T(0)) )
-        {
-        ++f_n_nz;
-        }
-      }
     }
   
   
-  if(size_found == true)
-    {
-    // take into account that indices start at 0
-    f_n_rows++;
-    f_n_cols++;
-    }
+  // take into account that indices start at 0
+  if(size_found)  { ++f_n_rows;  ++f_n_cols; }
   
   
-  if(load_okay == true)
+  if(load_okay)
     {
     f.clear();
     f.seekg(pos1);
     
-    x.set_size(f_n_rows, f_n_cols);
+    MapMat< std::complex<T> > tmp(f_n_rows, f_n_cols);
     
-    if(weird_format == false)
-      {
-      x.mem_resize(f_n_nz);
-      }
-    
-    uword pos = 0;
-    
-    while(f.good() == true)
+    while(f.good())
       {
       std::getline(f, line_string);
       
@@ -3222,31 +3023,12 @@ diskio::load_coord_ascii(SpMat< std::complex<T> >& x, std::istream& f, std::stri
         }
       
       
-      if( (final_val_real != T(0)) || (final_val_imag != T(0)) )
-        {
-        if(weird_format == false)
-          {
-          access::rw(x.row_indices[pos]) = line_row;
-          access::rw(x.values[pos])      = std::complex<T>(final_val_real, final_val_imag);
-          ++access::rw(x.col_ptrs[line_col + 1]);
-          
-          ++pos;
-          }
-        else
-          {
-          x.at(line_row,line_col) = std::complex<T>(final_val_real, final_val_imag);
-          }
-        }
+      const std::complex<T> final_val = std::complex<T>(final_val_real, final_val_imag);
+      
+      if(final_val != std::complex<T>(0))  { tmp(line_row,line_col) = final_val; }
       }
     
-    
-    if(weird_format == false)
-      {
-      for(uword c = 1; c <= f_n_cols; ++c)
-        {
-        access::rw(x.col_ptrs[c]) += x.col_ptrs[c - 1];
-        }
-      }
+    x = tmp;
     }
   
   return load_okay;
@@ -3426,6 +3208,7 @@ diskio::save_raw_ascii(const Cube<eT>& x, std::ostream& f)
   
   if(is_real<eT>::value)
     {
+    f.unsetf(ios::fixed);
     f.setf(ios::scientific);
     f.precision(14);
     cell_width = 22;
@@ -3433,6 +3216,7 @@ diskio::save_raw_ascii(const Cube<eT>& x, std::ostream& f)
   
   if(is_cx<eT>::value)
     {
+    f.unsetf(ios::fixed);
     f.setf(ios::scientific);
     f.precision(14);
     }
@@ -3559,6 +3343,7 @@ diskio::save_arma_ascii(const Cube<eT>& x, std::ostream& f)
   
   if(is_real<eT>::value)
     {
+    f.unsetf(ios::fixed);
     f.setf(ios::scientific);
     f.precision(14);
     cell_width = 22;
@@ -3566,6 +3351,7 @@ diskio::save_arma_ascii(const Cube<eT>& x, std::ostream& f)
   
   if(is_cx<eT>::value)
     {
+    f.unsetf(ios::fixed);
     f.setf(ios::scientific);
     f.precision(14);
     }
@@ -3655,7 +3441,7 @@ diskio::save_arma_binary(const Cube<eT>& x, std::ostream& f)
 template<typename eT>
 inline
 bool
-diskio::save_hdf5_binary(const Cube<eT>& x, const std::string& final_name)
+diskio::save_hdf5_binary(const Cube<eT>& x, const hdf5_name& spec)
   {
   arma_extra_debug_sigprint();
 
@@ -3670,7 +3456,7 @@ diskio::save_hdf5_binary(const Cube<eT>& x, const std::string& final_name)
 
     bool save_okay = false;
 
-    const std::string tmp_name = diskio::gen_tmp_name(final_name);
+    const std::string tmp_name = diskio::gen_tmp_name(spec.filename);
 
     // Set up the file according to HDF5's preferences
     hid_t file = arma_H5Fcreate(tmp_name.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
@@ -3687,10 +3473,28 @@ diskio::save_hdf5_binary(const Cube<eT>& x, const std::string& final_name)
     // If this returned something invalid, well, it's time to crash.
     arma_check(datatype == -1, "Cube::save(): unknown datatype for HDF5");
 
-    // MATLAB forces the users to specify a name at save time for HDF5; Octave
-    // will use the default of 'dataset' unless otherwise specified, so we will
-    // use that.
-    hid_t dataset = arma_H5Dcreate(file, "dataset", datatype, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    // MATLAB forces the users to specify a name at save time for HDF5;
+    // Octave will use the default of 'dataset' unless otherwise specified.
+    // If the user hasn't specified a dataset name, we will use 'dataset'
+    // We may have to split out the group name from the dataset name.
+    std::vector<hid_t> groups;
+    std::string full_name = spec.dsname;
+    size_t loc;
+    while ((loc = full_name.find("/")) != std::string::npos)
+      {
+      // Create another group...
+      if (loc != 0) // Ignore the first /, if there is a leading /.
+        {
+        hid_t gid = arma_H5Gcreate((groups.size() == 0) ? file : groups[groups.size() - 1], full_name.substr(0, loc).c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+        groups.push_back(gid);
+        }
+
+      full_name = full_name.substr(loc + 1);
+      }
+    
+    const std::string dataset_name = (full_name.empty() == false) ? full_name : std::string("dataset");
+    
+    hid_t dataset = arma_H5Dcreate(groups.size() == 0 ? file : groups[groups.size() - 1], dataset_name.c_str(), datatype, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
     herr_t status = arma_H5Dwrite(dataset, datatype, H5S_ALL, H5S_ALL, H5P_DEFAULT, x.mem);
     save_okay = (status >= 0);
@@ -3698,16 +3502,17 @@ diskio::save_hdf5_binary(const Cube<eT>& x, const std::string& final_name)
     arma_H5Dclose(dataset);
     arma_H5Tclose(datatype);
     arma_H5Sclose(dataspace);
+    for (size_t i = 0; i < groups.size(); ++i)  { arma_H5Gclose(groups[i]); }
     arma_H5Fclose(file);
 
-    if(save_okay == true) { save_okay = diskio::safe_rename(tmp_name, final_name); }
+    if(save_okay == true) { save_okay = diskio::safe_rename(tmp_name, spec.filename); }
 
     return save_okay;
     }
   #else
     {
     arma_ignore(x);
-    arma_ignore(final_name);
+    arma_ignore(spec);
 
     arma_stop_logic_error("Cube::save(): use of HDF5 needs to be enabled");
 
@@ -4048,13 +3853,12 @@ diskio::load_arma_binary(Cube<eT>& x, std::istream& f, std::string& err_msg)
 template<typename eT>
 inline
 bool
-diskio::load_hdf5_binary(Cube<eT>& x, const std::string& name, std::string& err_msg)
+diskio::load_hdf5_binary(Cube<eT>& x, const hdf5_name& spec, std::string& err_msg)
   {
   arma_extra_debug_sigprint();
 
   #if defined(ARMA_USE_HDF5)
     {
-
     // These may be necessary to store the error handler (if we need to).
     herr_t (*old_func)(hid_t, void*);
     void *old_client_data;
@@ -4071,19 +3875,31 @@ diskio::load_hdf5_binary(Cube<eT>& x, const std::string& name, std::string& err_
 
     bool load_okay = false;
 
-    hid_t fid = arma_H5Fopen(name.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+    hid_t fid = arma_H5Fopen(spec.filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
 
     if(fid >= 0)
       {
       // MATLAB HDF5 dataset names are user-specified;
       // Octave tends to store the datasets in a group, with the actual dataset being referred to as "value".
-      // So we will search for "dataset" and "value", and if those are not found we will take the first dataset we do find.
+      // If the user hasn't specified a dataset, we will search for "dataset" and "value",
+      // and if those are not found we will take the first dataset we do find.
+      
       std::vector<std::string> searchNames;
-      searchNames.push_back("dataset");
-      searchNames.push_back("value");
-
-      hid_t dataset = hdf5_misc::search_hdf5_file(searchNames, fid, 3, false);
-
+      
+      const bool exact = (spec.dsname.empty() == false);
+      
+      if(exact)
+        {
+        searchNames.push_back(spec.dsname);
+        }
+      else
+        {
+        searchNames.push_back("dataset");
+        searchNames.push_back("value"  );
+        }
+      
+      hid_t dataset = hdf5_misc::search_hdf5_file(searchNames, fid, 3, exact);
+      
       if(dataset >= 0)
         {
         hid_t filespace = arma_H5Dget_space(dataset);
@@ -4170,7 +3986,7 @@ diskio::load_hdf5_binary(Cube<eT>& x, const std::string& name, std::string& err_
   #else
     {
     arma_ignore(x);
-    arma_ignore(name);
+    arma_ignore(spec);
     arma_ignore(err_msg);
 
     arma_stop_logic_error("Cube::load(): use of HDF5 needs to be enabled");

--- a/inst/include/armadillo_bits/field_meat.hpp
+++ b/inst/include/armadillo_bits/field_meat.hpp
@@ -26,16 +26,10 @@ field<oT>::~field()
   
   delete_objects();
   
-  if(n_elem > field_prealloc_n_elem::val)
-    {
-    delete [] mem;
-    }
+  if(n_elem > field_prealloc_n_elem::val)  { delete [] mem; }
   
-  if(arma_config::debug == true)
-    {
-    // try to expose buggy user code that accesses deleted objects
-    mem = 0;
-    }
+  // try to expose buggy user code that accesses deleted objects
+  if(arma_config::debug)  { mem = 0; }
   }
 
 
@@ -1345,14 +1339,14 @@ field<oT>::print(const std::string extra_text) const
   
   if(extra_text.length() != 0)
     {
-    const std::streamsize orig_width = ARMA_DEFAULT_OSTREAM.width();
+    const std::streamsize orig_width = get_cout_stream().width();
     
-    ARMA_DEFAULT_OSTREAM << extra_text << '\n';
-  
-    ARMA_DEFAULT_OSTREAM.width(orig_width);
+    get_cout_stream() << extra_text << '\n';
+    
+    get_cout_stream().width(orig_width);
     }
   
-  arma_ostream::print(ARMA_DEFAULT_OSTREAM, *this);
+  arma_ostream::print(get_cout_stream(), *this);
   }
 
 

--- a/inst/include/armadillo_bits/fn_chol.hpp
+++ b/inst/include/armadillo_bits/fn_chol.hpp
@@ -60,7 +60,7 @@ chol
   
   if(status == false)
     {
-    out.reset();
+    out.soft_reset();
     arma_debug_warn("chol(): decomposition failed");
     }
   

--- a/inst/include/armadillo_bits/fn_eig_gen.hpp
+++ b/inst/include/armadillo_bits/fn_eig_gen.hpp
@@ -39,7 +39,7 @@ eig_gen
   
   if(status == false)
     {
-    eigvals.reset();
+    eigvals.soft_reset();
     arma_stop_runtime_error("eig_gen(): decomposition failed");
     }
   
@@ -68,7 +68,7 @@ eig_gen
   
   if(status == false)
     {
-    eigvals.reset();
+    eigvals.soft_reset();
     arma_debug_warn("eig_gen(): decomposition failed");
     }
   
@@ -95,8 +95,8 @@ eig_gen
   
   if(status == false)
     {
-    eigvals.reset();
-    eigvecs.reset();
+    eigvals.soft_reset();
+    eigvecs.soft_reset();
     arma_debug_warn("eig_gen(): decomposition failed");
     }
   

--- a/inst/include/armadillo_bits/fn_eig_pair.hpp
+++ b/inst/include/armadillo_bits/fn_eig_pair.hpp
@@ -39,7 +39,7 @@ eig_pair
   
   if(status == false)
     {
-    eigvals.reset();
+    eigvals.soft_reset();
     arma_stop_runtime_error("eig_pair(): decomposition failed");
     }
   
@@ -68,7 +68,7 @@ eig_pair
   
   if(status == false)
     {
-    eigvals.reset();
+    eigvals.soft_reset();
     arma_debug_warn("eig_pair(): decomposition failed");
     }
   
@@ -96,8 +96,8 @@ eig_pair
   
   if(status == false)
     {
-    eigvals.reset();
-    eigvecs.reset();
+    eigvals.soft_reset();
+    eigvecs.soft_reset();
     arma_debug_warn("eig_pair(): decomposition failed");
     }
   

--- a/inst/include/armadillo_bits/fn_eig_sym.hpp
+++ b/inst/include/armadillo_bits/fn_eig_sym.hpp
@@ -39,7 +39,7 @@ eig_sym
   
   if(status == false)
     {
-    eigval.reset();
+    eigval.soft_reset();
     arma_debug_warn("eig_sym(): decomposition failed");
     }
   
@@ -67,7 +67,7 @@ eig_sym
 
   if(status == false)
     {
-    out.reset();
+    out.soft_reset();
     arma_stop_runtime_error("eig_sym(): decomposition failed");
     }
   
@@ -114,8 +114,8 @@ eig_sym
   
   if(status == false)
     {
-    eigval.reset();
-    eigvec.reset();
+    eigval.soft_reset();
+    eigvec.soft_reset();
     arma_debug_warn("eig_sym(): decomposition failed");
     }
   else

--- a/inst/include/armadillo_bits/fn_eigs_gen.hpp
+++ b/inst/include/armadillo_bits/fn_eigs_gen.hpp
@@ -44,7 +44,7 @@ eigs_gen
   
   if(status == false)
     {
-    eigval.reset();
+    eigval.soft_reset();
     arma_stop_runtime_error("eigs_gen(): decomposition failed");
     }
   
@@ -78,7 +78,7 @@ eigs_gen
   
   if(status == false)
     {
-    eigval.reset();
+    eigval.soft_reset();
     arma_debug_warn("eigs_gen(): decomposition failed");
     }
   
@@ -111,8 +111,8 @@ eigs_gen
   
   if(status == false)
     {
-    eigval.reset();
-    eigvec.reset();
+    eigval.soft_reset();
+    eigvec.soft_reset();
     arma_debug_warn("eigs_gen(): decomposition failed");
     }
   

--- a/inst/include/armadillo_bits/fn_eigs_sym.hpp
+++ b/inst/include/armadillo_bits/fn_eigs_sym.hpp
@@ -42,7 +42,7 @@ eigs_sym
   
   if(status == false)
     {
-    eigval.reset();
+    eigval.soft_reset();
     arma_stop_runtime_error("eigs_sym(): decomposition failed");
     }
   
@@ -74,7 +74,7 @@ eigs_sym
   
   if(status == false)
     {
-    eigval.reset();
+    eigval.soft_reset();
     arma_debug_warn("eigs_sym(): decomposition failed");
     }
   
@@ -107,7 +107,8 @@ eigs_sym
   
   if(status == false)
     {
-    eigval.reset();
+    eigval.soft_reset();
+    eigvec.soft_reset();
     arma_debug_warn("eigs_sym(): decomposition failed");
     }
   

--- a/inst/include/armadillo_bits/fn_expmat.hpp
+++ b/inst/include/armadillo_bits/fn_expmat.hpp
@@ -53,7 +53,7 @@ expmat(Mat<typename T1::elem_type>& B, const Base<typename T1::elem_type,T1>& A)
   if(status == false)
     {
     arma_debug_warn("expmat(): given matrix appears ill-conditioned");
-    B.reset();
+    B.soft_reset();
     return false;
     }
   
@@ -90,7 +90,7 @@ expmat_sym(Mat<typename T1::elem_type>& Y, const Base<typename T1::elem_type,T1>
   
   if(status == false)
     {
-    Y.reset();
+    Y.soft_reset();
     arma_debug_warn("expmat_sym(): transformation failed");
     }
   

--- a/inst/include/armadillo_bits/fn_kmeans.hpp
+++ b/inst/include/armadillo_bits/fn_kmeans.hpp
@@ -46,7 +46,7 @@ kmeans
     }
   else
     {
-    means.reset();
+    means.soft_reset();
     }
   
   return status;

--- a/inst/include/armadillo_bits/fn_logmat.hpp
+++ b/inst/include/armadillo_bits/fn_logmat.hpp
@@ -56,7 +56,7 @@ logmat(Mat< std::complex<typename T1::elem_type> >& Y, const Base<typename T1::e
   
   if(status == false)
     {
-    Y.reset();
+    Y.soft_reset();
     arma_debug_warn("logmat(): transformation failed");
     }
   
@@ -76,7 +76,7 @@ logmat(Mat<typename T1::elem_type>& Y, const Base<typename T1::elem_type,T1>& X,
   
   if(status == false)
     {
-    Y.reset();
+    Y.soft_reset();
     arma_debug_warn("logmat(): transformation failed");
     }
   
@@ -113,7 +113,7 @@ logmat_sympd(Mat<typename T1::elem_type>& Y, const Base<typename T1::elem_type,T
   
   if(status == false)
     {
-    Y.reset();
+    Y.soft_reset();
     arma_debug_warn("logmat_sympd(): transformation failed");
     }
   

--- a/inst/include/armadillo_bits/fn_lu.hpp
+++ b/inst/include/armadillo_bits/fn_lu.hpp
@@ -40,8 +40,8 @@ lu
   
   if(status == false)
     {
-    L.reset();
-    U.reset();
+    L.soft_reset();
+    U.soft_reset();
     arma_debug_warn("lu(): decomposition failed");
     }
   
@@ -72,9 +72,9 @@ lu
   
   if(status == false)
     {
-    L.reset();
-    U.reset();
-    P.reset();
+    L.soft_reset();
+    U.soft_reset();
+    P.soft_reset();
     arma_debug_warn("lu(): decomposition failed");
     }
   

--- a/inst/include/armadillo_bits/fn_misc.hpp
+++ b/inst/include/armadillo_bits/fn_misc.hpp
@@ -658,4 +658,21 @@ sub2ind(const SizeCube& s, const Base<uword,T1>& subscripts)
 
 
 
+template<typename T1, typename T2>
+arma_inline
+typename
+enable_if2
+  <
+  (is_arma_type<T1>::value && is_same_type<typename T1::elem_type, typename T2::elem_type>::value),
+  const Glue<T1, T2, glue_affmul>
+  >::result
+affmul(const T1& A, const T2& B)
+  {
+  arma_extra_debug_sigprint();
+  
+  return Glue<T1, T2, glue_affmul>(A,B);
+  }
+
+
+
 //! @}

--- a/inst/include/armadillo_bits/fn_polyfit.hpp
+++ b/inst/include/armadillo_bits/fn_polyfit.hpp
@@ -35,7 +35,7 @@ polyfit(Mat<typename T1::elem_type>& out, const Base<typename T1::elem_type, T1>
   
   if(status == false)
     {
-    out.reset();
+    out.soft_reset();
     arma_debug_warn("polyfit(): failed");
     }
   

--- a/inst/include/armadillo_bits/fn_princomp.hpp
+++ b/inst/include/armadillo_bits/fn_princomp.hpp
@@ -45,10 +45,10 @@ princomp
   
   if(status == false)
     {
-    coeff_out.reset();
-    score_out.reset();
-    latent_out.reset();
-    tsquared_out.reset();
+    coeff_out.soft_reset();
+    score_out.soft_reset();
+    latent_out.soft_reset();
+    tsquared_out.soft_reset();
     
     arma_debug_warn("princomp(): decomposition failed");
     }
@@ -82,9 +82,9 @@ princomp
   
   if(status == false)
     {
-    coeff_out.reset();
-    score_out.reset();
-    latent_out.reset();
+    coeff_out.soft_reset();
+    score_out.soft_reset();
+    latent_out.soft_reset();
     
     arma_debug_warn("princomp(): decomposition failed");
     }
@@ -116,8 +116,8 @@ princomp
   
   if(status == false)
     {
-    coeff_out.reset();
-    score_out.reset();
+    coeff_out.soft_reset();
+    score_out.soft_reset();
     
     arma_debug_warn("princomp(): decomposition failed");
     }
@@ -147,7 +147,7 @@ princomp
   
   if(status == false)
     {
-    coeff_out.reset();
+    coeff_out.soft_reset();
     
     arma_debug_warn("princomp(): decomposition failed");
     }

--- a/inst/include/armadillo_bits/fn_qr.hpp
+++ b/inst/include/armadillo_bits/fn_qr.hpp
@@ -40,8 +40,8 @@ qr
   
   if(status == false)
     {
-    Q.reset();
-    R.reset();
+    Q.soft_reset();
+    R.soft_reset();
     arma_debug_warn("qr(): decomposition failed");
     }
   
@@ -71,8 +71,8 @@ qr_econ
   
   if(status == false)
     {
-    Q.reset();
-    R.reset();
+    Q.soft_reset();
+    R.soft_reset();
     arma_debug_warn("qr_econ(): decomposition failed");
     }
   

--- a/inst/include/armadillo_bits/fn_schur.hpp
+++ b/inst/include/armadillo_bits/fn_schur.hpp
@@ -39,7 +39,7 @@ schur
   
   if(status == false)
     {
-    S.reset();
+    S.soft_reset();
     arma_debug_warn("schur(): decomposition failed");
     }
   
@@ -70,7 +70,7 @@ schur
   
   if(status == false)
     {
-    S.reset();
+    S.soft_reset();
     arma_stop_runtime_error("schur(): decomposition failed");
     }
   
@@ -99,8 +99,8 @@ schur
   
   if(status == false)
     {
-    U.reset();
-    S.reset();
+    U.soft_reset();
+    S.soft_reset();
     arma_debug_warn("schur(): decomposition failed");
     }
   

--- a/inst/include/armadillo_bits/fn_spsolve.hpp
+++ b/inst/include/armadillo_bits/fn_spsolve.hpp
@@ -98,7 +98,7 @@ spsolve_helper
     if(rcond > T(0))  { arma_debug_warn("spsolve(): system seems singular (rcond: ", rcond, ")"); }
     else              { arma_debug_warn("spsolve(): system seems singular");                      }
     
-    out.reset();
+    out.soft_reset();
     }
   
   return status;

--- a/inst/include/armadillo_bits/fn_sqrtmat.hpp
+++ b/inst/include/armadillo_bits/fn_sqrtmat.hpp
@@ -111,7 +111,7 @@ sqrtmat_sympd(Mat<typename T1::elem_type>& Y, const Base<typename T1::elem_type,
   
   if(status == false)
     {
-    Y.reset();
+    Y.soft_reset();
     arma_debug_warn("sqrtmat_sympd(): transformation failed");
     }
   

--- a/inst/include/armadillo_bits/fn_svd.hpp
+++ b/inst/include/armadillo_bits/fn_svd.hpp
@@ -38,7 +38,7 @@ svd
   
   if(status == false)
     {
-    S.reset();
+    S.soft_reset();
     arma_debug_warn("svd(): decomposition failed");
     }
   
@@ -66,7 +66,7 @@ svd
   
   if(status == false)
     {
-    out.reset();
+    out.soft_reset();
     arma_stop_runtime_error("svd(): decomposition failed");
     }
   
@@ -106,9 +106,9 @@ svd
   
   if(status == false)
     {
-    U.reset();
-    S.reset();
-    V.reset();
+    U.soft_reset();
+    S.soft_reset();
+    V.soft_reset();
     arma_debug_warn("svd(): decomposition failed");
     }
   
@@ -154,9 +154,9 @@ svd_econ
   
   if(status == false)
     {
-    U.reset();
-    S.reset();
-    V.reset();
+    U.soft_reset();
+    S.soft_reset();
+    V.soft_reset();
     arma_debug_warn("svd(): decomposition failed");
     }
   

--- a/inst/include/armadillo_bits/fn_svds.hpp
+++ b/inst/include/armadillo_bits/fn_svds.hpp
@@ -85,9 +85,9 @@ svds_helper
     
     if(status == false)
       {
-      U.reset();
-      S.reset();
-      V.reset();
+      U.soft_reset();
+      S.soft_reset();
+      V.soft_reset();
       
       return false;
       }
@@ -206,9 +206,9 @@ svds_helper
     
     if(status == false)
       {
-      U.reset();
-      S.reset();
-      V.reset();
+      U.soft_reset();
+      S.soft_reset();
+      V.soft_reset();
       
       return false;
       }

--- a/inst/include/armadillo_bits/fn_syl_lyap.hpp
+++ b/inst/include/armadillo_bits/fn_syl_lyap.hpp
@@ -48,7 +48,7 @@ syl
   
   if(status == false)
     {
-    out.reset();
+    out.soft_reset();
     arma_debug_warn("syl(): solution not found");
     }
   
@@ -88,7 +88,7 @@ syl
   
   if(status == false)
     {
-    out.reset();
+    out.soft_reset();
     arma_stop_runtime_error("syl(): solution not found");
     }
   

--- a/inst/include/armadillo_bits/glue_affmul_bones.hpp
+++ b/inst/include/armadillo_bits/glue_affmul_bones.hpp
@@ -14,45 +14,23 @@
 // ------------------------------------------------------------------------
 
 
-//! \addtogroup arma_version
+//! \addtogroup glue_affmul
 //! @{
 
 
 
-#define ARMA_VERSION_MAJOR 8
-#define ARMA_VERSION_MINOR 100
-#define ARMA_VERSION_PATCH 0
-#define ARMA_VERSION_NAME  "Feral Pursuits"
-
-
-
-struct arma_version
+class glue_affmul
   {
-  static const unsigned int major = ARMA_VERSION_MAJOR;
-  static const unsigned int minor = ARMA_VERSION_MINOR;
-  static const unsigned int patch = ARMA_VERSION_PATCH;
+  public:
   
-  static
-  inline
-  std::string
-  as_string()
-    {
-    const char* nickname = ARMA_VERSION_NAME;
-    
-    std::stringstream ss;
-    ss << arma_version::major
-       << '.'
-       << arma_version::minor
-       << '.'
-       << arma_version::patch
-       << " ("
-       << nickname
-       << ')';
-    
-    return ss.str();
-    }
+  template<typename T1, typename T2>
+  inline static void apply(Mat<typename T1::elem_type>& out, const Glue<T1,T2,glue_affmul>& X);
+  
+  template<typename T1, typename T2>
+  inline static void apply_noalias(Mat<typename T1::elem_type>& out, const T1& A, const T2& B);
   };
 
 
 
 //! @}
+

--- a/inst/include/armadillo_bits/glue_affmul_meat.hpp
+++ b/inst/include/armadillo_bits/glue_affmul_meat.hpp
@@ -1,0 +1,246 @@
+// Copyright 2008-2016 Conrad Sanderson (http://conradsanderson.id.au)
+// Copyright 2008-2016 National ICT Australia (NICTA)
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+
+//! \addtogroup glue_affmul
+//! @{
+
+
+
+template<typename T1, typename T2>
+inline
+void
+glue_affmul::apply(Mat<typename T1::elem_type>& out, const Glue<T1,T2,glue_affmul>& X)
+  {
+  arma_extra_debug_sigprint();
+  
+  typedef typename T1::elem_type eT;
+  
+  const quasi_unwrap<T1> U1(X.A);
+  const quasi_unwrap<T2> U2(X.B);
+  
+  const bool is_alias = (U1.is_alias(out) || U2.is_alias(out));
+  
+  if(is_alias == false)
+    {
+    glue_affmul::apply_noalias(out, U1.M, U2.M);
+    }
+  else
+    {
+    Mat<eT> tmp;
+    
+    glue_affmul::apply_noalias(tmp, U1.M, U2.M);
+    
+    out.steal_mem(tmp);
+    }
+  }
+
+
+
+template<typename T1, typename T2>
+inline
+void
+glue_affmul::apply_noalias(Mat<typename T1::elem_type>& out, const T1& A, const T2& B)
+  {
+  arma_extra_debug_sigprint();
+  
+  typedef typename T1::elem_type eT;
+  
+  const uword N = A.n_rows;
+  
+  arma_debug_check( (N != A.n_cols  ), "affmul(): first object must be a square matrix" );
+  arma_debug_check( (N != B.n_rows+1), "affmul(): size mismatch"                        );
+  
+  const uword B_n_cols = B.n_cols;
+  
+  out.set_size(N, B_n_cols);
+  
+  if(out.n_elem == 0)  { return; }
+  
+  const eT* A_mem = A.memptr();
+  
+  switch(N)
+    {
+    case 0:
+      break;
+    
+    case 1:
+      out.fill(A_mem[0]);
+      break;
+    
+    case 2:
+      {
+      if(B_n_cols == 1)
+        {
+        const eT*   B_mem =   B.memptr();
+              eT* out_mem = out.memptr();
+        
+        const eT x = B_mem[0];
+        
+        out_mem[0] = A_mem[0]*x + A_mem[2];
+        out_mem[1] = A_mem[1]*x + A_mem[3];
+        }
+      else
+      for(uword col=0; col < B_n_cols; ++col)
+        {
+        const eT*   B_mem =   B.colptr(col);
+              eT* out_mem = out.colptr(col);
+        
+        const eT x = B_mem[0];
+        
+        out_mem[0] = A_mem[0]*x + A_mem[2];
+        out_mem[1] = A_mem[1]*x + A_mem[3];
+        }
+      }
+      break;
+    
+    case 3:
+      {
+      if(B_n_cols == 1)
+        {
+        const eT*   B_mem =   B.memptr();
+              eT* out_mem = out.memptr();
+        
+        const eT x = B_mem[0];
+        const eT y = B_mem[1];
+        
+        out_mem[0] = A_mem[0]*x + A_mem[3]*y + A_mem[6];
+        out_mem[1] = A_mem[1]*x + A_mem[4]*y + A_mem[7];
+        out_mem[2] = A_mem[2]*x + A_mem[5]*y + A_mem[8];
+        }
+      else
+      for(uword col=0; col < B_n_cols; ++col)
+        {
+        const eT*   B_mem =   B.colptr(col);
+              eT* out_mem = out.colptr(col);
+        
+        const eT x = B_mem[0];
+        const eT y = B_mem[1];
+        
+        out_mem[0] = A_mem[0]*x + A_mem[3]*y + A_mem[6];
+        out_mem[1] = A_mem[1]*x + A_mem[4]*y + A_mem[7];
+        out_mem[2] = A_mem[2]*x + A_mem[5]*y + A_mem[8];
+        }
+      }
+      break;
+    
+    case 4:
+      {
+      if(B_n_cols == 1)
+        {
+        const eT*   B_mem =   B.memptr();
+              eT* out_mem = out.memptr();
+        
+        const eT x = B_mem[0];
+        const eT y = B_mem[1];
+        const eT z = B_mem[2];
+        
+        out_mem[0] = A_mem[ 0]*x + A_mem[ 4]*y + A_mem[ 8]*z + A_mem[12];
+        out_mem[1] = A_mem[ 1]*x + A_mem[ 5]*y + A_mem[ 9]*z + A_mem[13];
+        out_mem[2] = A_mem[ 2]*x + A_mem[ 6]*y + A_mem[10]*z + A_mem[14];
+        out_mem[3] = A_mem[ 3]*x + A_mem[ 7]*y + A_mem[11]*z + A_mem[15];
+        }
+      else
+      for(uword col=0; col < B_n_cols; ++col)
+        {
+        const eT*   B_mem =   B.colptr(col);
+              eT* out_mem = out.colptr(col);
+        
+        const eT x = B_mem[0];
+        const eT y = B_mem[1];
+        const eT z = B_mem[2];
+        
+        out_mem[0] = A_mem[ 0]*x + A_mem[ 4]*y + A_mem[ 8]*z + A_mem[12];
+        out_mem[1] = A_mem[ 1]*x + A_mem[ 5]*y + A_mem[ 9]*z + A_mem[13];
+        out_mem[2] = A_mem[ 2]*x + A_mem[ 6]*y + A_mem[10]*z + A_mem[14];
+        out_mem[3] = A_mem[ 3]*x + A_mem[ 7]*y + A_mem[11]*z + A_mem[15];
+        }
+      }
+      break;
+    
+    case 5:
+      {
+      if(B_n_cols == 1)
+        {
+        const eT*   B_mem =   B.memptr();
+              eT* out_mem = out.memptr();
+        
+        const eT x = B_mem[0];
+        const eT y = B_mem[1];
+        const eT z = B_mem[2];
+        const eT w = B_mem[3];
+        
+        out_mem[0] = A_mem[ 0]*x + A_mem[ 5]*y + A_mem[10]*z + A_mem[15]*w + A_mem[20];
+        out_mem[1] = A_mem[ 1]*x + A_mem[ 6]*y + A_mem[11]*z + A_mem[16]*w + A_mem[21];
+        out_mem[2] = A_mem[ 2]*x + A_mem[ 7]*y + A_mem[12]*z + A_mem[17]*w + A_mem[22];
+        out_mem[3] = A_mem[ 3]*x + A_mem[ 8]*y + A_mem[13]*z + A_mem[18]*w + A_mem[23];
+        out_mem[4] = A_mem[ 4]*x + A_mem[ 9]*y + A_mem[14]*z + A_mem[19]*w + A_mem[24];
+        }
+      else
+      for(uword col=0; col < B_n_cols; ++col)
+        {
+        const eT*   B_mem =   B.colptr(col);
+              eT* out_mem = out.colptr(col);
+        
+        const eT x = B_mem[0];
+        const eT y = B_mem[1];
+        const eT z = B_mem[2];
+        const eT w = B_mem[3];
+        
+        out_mem[0] = A_mem[ 0]*x + A_mem[ 5]*y + A_mem[10]*z + A_mem[15]*w + A_mem[20];
+        out_mem[1] = A_mem[ 1]*x + A_mem[ 6]*y + A_mem[11]*z + A_mem[16]*w + A_mem[21];
+        out_mem[2] = A_mem[ 2]*x + A_mem[ 7]*y + A_mem[12]*z + A_mem[17]*w + A_mem[22];
+        out_mem[3] = A_mem[ 3]*x + A_mem[ 8]*y + A_mem[13]*z + A_mem[18]*w + A_mem[23];
+        out_mem[4] = A_mem[ 4]*x + A_mem[ 9]*y + A_mem[14]*z + A_mem[19]*w + A_mem[24];
+        }
+      }
+      break;
+    
+    default:
+      {
+      if(B_n_cols == 1)
+        {
+        Col<eT> tmp(N);
+        eT*     tmp_mem = tmp.memptr();
+        
+        arrayops::copy(tmp_mem, B.memptr(), N-1);
+        
+        tmp_mem[N-1] = eT(1);
+        
+        out = A * tmp;
+        }
+      else
+        {
+        Mat<eT> tmp(N, B_n_cols);
+        
+        for(uword col=0; col < B_n_cols; ++col)
+          {
+          const eT*   B_mem =   B.colptr(col);
+                eT* tmp_mem = tmp.colptr(col);
+          
+          arrayops::copy(tmp_mem, B_mem, N-1);
+          
+          tmp_mem[N-1] = eT(1);
+          }
+        
+        out = A * tmp;
+        }
+      }
+    }
+  }
+
+
+
+//! @}

--- a/inst/include/armadillo_bits/glue_conv_meat.hpp
+++ b/inst/include/armadillo_bits/glue_conv_meat.hpp
@@ -19,6 +19,7 @@
 
 
 
+// TODO: this implementation of conv() is rudimentary; replace with faster version
 template<typename eT>
 inline
 void
@@ -59,7 +60,7 @@ glue_conv::apply(Mat<eT>& out, const Mat<eT>& A, const Mat<eT>& B, const bool A_
   (A_is_col) ? out.set_size(out_n_elem, 1) : out.set_size(1, out_n_elem);
   
   eT* out_mem = out.memptr();
-        
+  
   for(uword i=0; i < out_n_elem; ++i)
     {
     // out_mem[i] = dot( hh, xx.subvec(i, (i + h_n_elem_m1)) );
@@ -67,6 +68,98 @@ glue_conv::apply(Mat<eT>& out, const Mat<eT>& A, const Mat<eT>& B, const bool A_
     out_mem[i] = op_dot::direct_dot( h_n_elem, hh_mem, &(xx_mem[i]) );
     }
   }
+
+
+
+// // alternative implementation of 1d convolution
+// template<typename eT>
+// inline
+// void
+// glue_conv::apply(Mat<eT>& out, const Mat<eT>& A, const Mat<eT>& B, const bool A_is_col)
+//   {
+//   arma_extra_debug_sigprint();
+//   
+//   const Mat<eT>& h = (A.n_elem <= B.n_elem) ? A : B;
+//   const Mat<eT>& x = (A.n_elem <= B.n_elem) ? B : A;
+//   
+//   const uword   h_n_elem    = h.n_elem;
+//   const uword   h_n_elem_m1 = h_n_elem - 1;
+//   const uword   x_n_elem    = x.n_elem;
+//   const uword out_n_elem    = ((h_n_elem + x_n_elem) > 0) ? (h_n_elem + x_n_elem - 1) : uword(0);
+//   
+//   if( (h_n_elem == 0) || (x_n_elem == 0) )  { out.zeros(); return; }
+//   
+//   
+//   Col<eT> hh(h_n_elem);  // flipped version of h
+//   
+//   const eT*   h_mem =  h.memptr();
+//         eT*  hh_mem = hh.memptr();
+//   
+//   for(uword i=0; i < h_n_elem; ++i)
+//     {
+//     hh_mem[h_n_elem_m1-i] = h_mem[i];
+//     }
+//   
+//   // construct HH matrix, with the column containing shifted versions of hh;
+//   // upper limit for number of zeros is about 50%; may not be optimal
+//   const uword N_copies = (std::min)(uword(10), h_n_elem); 
+//   
+//   const uword HH_n_rows = h_n_elem + (N_copies-1);
+//   
+//   Mat<eT> HH(HH_n_rows, N_copies, fill::zeros);
+//   
+//   for(uword i=0; i<N_copies; ++i)
+//     {
+//     arrayops::copy(HH.colptr(i) + i, hh.memptr(), h_n_elem);
+//     }
+//   
+//   
+//   
+//   Col<eT> xx( (x_n_elem + 2*h_n_elem_m1), fill::zeros );  // zero padded version of x
+//   
+//   const eT*  x_mem =  x.memptr();
+//         eT* xx_mem = xx.memptr();
+//   
+//   arrayops::copy( &(xx_mem[h_n_elem_m1]), x_mem, x_n_elem );
+//   
+//   
+//   (A_is_col) ? out.set_size(out_n_elem, 1) : out.set_size(1, out_n_elem);
+//   
+//   eT* out_mem = out.memptr();
+//   
+//   uword last_i      = 0;
+//   bool  last_i_done = false;
+//   
+//   for(uword i=0; i < xx.n_elem; i += N_copies)
+//     {
+//     if( ((i + HH_n_rows) <= xx.n_elem) && ((i + N_copies) <= out_n_elem) ) 
+//       {
+//       const Row<eT> xx_sub(xx_mem + i, HH_n_rows, false, true);
+//       
+//       Row<eT> out_sub(out_mem + i, N_copies, false, true);
+//       
+//       out_sub = xx_sub * HH;
+//       
+//       last_i_done = true;
+//       }
+//     else
+//       {
+//       last_i = i;
+//       last_i_done = false;
+//       break;
+//       }
+//     }
+//   
+//   if(last_i_done == false)
+//     {
+//     for(uword i=last_i; i < out_n_elem; ++i)
+//       {
+//       // out_mem[i] = dot( hh, xx.subvec(i, (i + h_n_elem_m1)) );
+//       
+//       out_mem[i] = op_dot::direct_dot( h_n_elem, hh_mem, &(xx_mem[i]) );
+//       }
+//     }
+//   }
 
 
 
@@ -125,6 +218,7 @@ glue_conv::apply(Mat<typename T1::elem_type>& out, const Glue<T1,T2,glue_conv>& 
 
 
 
+// TODO: this implementation of conv2() is rudimentary; replace with faster version
 template<typename eT>
 inline
 void

--- a/inst/include/armadillo_bits/glue_polyfit_meat.hpp
+++ b/inst/include/armadillo_bits/glue_polyfit_meat.hpp
@@ -121,7 +121,7 @@ glue_polyfit::apply(Mat<typename T1::elem_type>& out, const Glue<T1,T2,glue_poly
   
   if(status == false)
     {
-    out.reset();
+    out.soft_reset();
     arma_stop_runtime_error("polyfit(): failed");
     }
   }

--- a/inst/include/armadillo_bits/glue_solve_meat.hpp
+++ b/inst/include/armadillo_bits/glue_solve_meat.hpp
@@ -124,7 +124,7 @@ glue_solve_gen::apply(Mat<eT>& out, const Base<eT,T1>& A_expr, const Base<eT,T2>
     }
   
   
-  if(status == false)  { out.reset(); }
+  if(status == false)  { out.soft_reset(); }
   
   return status;
   }
@@ -198,7 +198,7 @@ glue_solve_tri::apply(Mat<eT>& out, const Base<eT,T1>& A_expr, const Base<eT,T2>
     }
   
   
-  if(status == false)  { out.reset(); }
+  if(status == false)  { out.soft_reset(); }
   
   return status;
   }

--- a/inst/include/armadillo_bits/glue_times_meat.hpp
+++ b/inst/include/armadillo_bits/glue_times_meat.hpp
@@ -102,7 +102,7 @@ glue_times_redirect2_helper<true>::apply(Mat<typename T1::elem_type>& out, const
     
     if(status == false)
       {
-      out.reset();
+      out.soft_reset();
       arma_stop_runtime_error("matrix multiplication: inverse of singular matrix; suggest to use solve() instead");
       }
     
@@ -221,7 +221,7 @@ glue_times_redirect3_helper<true>::apply(Mat<typename T1::elem_type>& out, const
     
     if(status == false)
       {
-      out.reset();
+      out.soft_reset();
       arma_stop_runtime_error("matrix multiplication: inverse of singular matrix; suggest to use solve() instead");
       }
     
@@ -252,7 +252,7 @@ glue_times_redirect3_helper<true>::apply(Mat<typename T1::elem_type>& out, const
     
     if(status == false)
       {
-      out.reset();
+      out.soft_reset();
       arma_stop_runtime_error("matrix multiplication: inverse of singular matrix; suggest to use solve() instead");
       return;
       }

--- a/inst/include/armadillo_bits/gmm_diag_meat.hpp
+++ b/inst/include/armadillo_bits/gmm_diag_meat.hpp
@@ -793,7 +793,7 @@ gmm_diag<eT>::learn
     
     reset(X.n_rows, N_gaus);
     
-    if(print_mode)  { get_stream_err2() << "gmm_diag::learn(): generating initial means\n"; get_stream_err2().flush(); }
+    if(print_mode)  { get_cout_stream() << "gmm_diag::learn(): generating initial means\n"; get_cout_stream().flush(); }
     
          if(dist_mode == eucl_dist)  { generate_initial_means<1>(X, seed_mode); }
     else if(dist_mode == maha_dist)  { generate_initial_means<2>(X, seed_mode); }
@@ -804,14 +804,14 @@ gmm_diag<eT>::learn
   
   if(km_iter > 0)
     {
-    const arma_ostream_state stream_state(get_stream_err2());
+    const arma_ostream_state stream_state(get_cout_stream());
     
     bool status = false;
     
          if(dist_mode == eucl_dist)  { status = km_iterate<1>(X, km_iter, print_mode, "gmm_diag::learn(): k-means"); }
     else if(dist_mode == maha_dist)  { status = km_iterate<2>(X, km_iter, print_mode, "gmm_diag::learn(): k-means"); }
     
-    stream_state.restore(get_stream_err2());
+    stream_state.restore(get_cout_stream());
     
     if(status == false)  { arma_debug_warn("gmm_diag::learn(): k-means algorithm failed; not enough data, or too many gaussians requested"); init(orig); return false; }
     }
@@ -823,7 +823,7 @@ gmm_diag<eT>::learn
   
   if(seed_mode != keep_existing)
     {
-    if(print_mode)  { get_stream_err2() << "gmm_diag::learn(): generating initial covariances\n"; get_stream_err2().flush(); }
+    if(print_mode)  { get_cout_stream() << "gmm_diag::learn(): generating initial covariances\n"; get_cout_stream().flush(); }
     
          if(dist_mode == eucl_dist)  { generate_initial_params<1>(X, var_floor_actual); }
     else if(dist_mode == maha_dist)  { generate_initial_params<2>(X, var_floor_actual); }
@@ -834,11 +834,11 @@ gmm_diag<eT>::learn
   
   if(em_iter > 0)
     {
-    const arma_ostream_state stream_state(get_stream_err2());
+    const arma_ostream_state stream_state(get_cout_stream());
     
     const bool status = em_iterate(X, em_iter, var_floor_actual, print_mode);
     
-    stream_state.restore(get_stream_err2());
+    stream_state.restore(get_cout_stream());
     
     if(status == false)  { arma_debug_warn("gmm_diag::learn(): EM algorithm failed"); init(orig); return false; }
     }
@@ -903,7 +903,7 @@ gmm_diag<eT>::kmeans_wrapper
     
     access::rw(means).zeros(X.n_rows, N_gaus);
     
-    if(print_mode)  { get_stream_err2() << "kmeans(): generating initial means\n"; }
+    if(print_mode)  { get_cout_stream() << "kmeans(): generating initial means\n"; }
     
     generate_initial_means<1>(X, seed_mode);
     }
@@ -913,13 +913,13 @@ gmm_diag<eT>::kmeans_wrapper
   
   if(km_iter > 0)
     {
-    const arma_ostream_state stream_state(get_stream_err2());
+    const arma_ostream_state stream_state(get_cout_stream());
     
     bool status = false;
     
     status = km_iterate<1>(X, km_iter, print_mode, "kmeans()");
     
-    stream_state.restore(get_stream_err2());
+    stream_state.restore(get_cout_stream());
     
     if(status == false)  { arma_debug_warn("kmeans(): clustering failed; not enough data, or too many means requested"); return false; }
     }
@@ -1080,7 +1080,7 @@ gmm_diag<eT>::internal_gen_boundaries(const uword N) const
     static const uword n_threads = 1;
   #endif
   
-  // get_stream_err2() << "gmm_diag::internal_gen_boundaries(): n_threads: " << n_threads << '\n';
+  // get_cout_stream() << "gmm_diag::internal_gen_boundaries(): n_threads: " << n_threads << '\n';
   
   umat boundaries(2, n_threads);
   
@@ -1106,7 +1106,7 @@ gmm_diag<eT>::internal_gen_boundaries(const uword N) const
     boundaries.zeros();
     }
   
-  // get_stream_err2() << "gmm_diag::internal_gen_boundaries(): boundaries: " << '\n' << boundaries << '\n';
+  // get_cout_stream() << "gmm_diag::internal_gen_boundaries(): boundaries: " << '\n' << boundaries << '\n';
   
   return boundaries;
   }
@@ -1959,7 +1959,7 @@ gmm_diag<eT>::generate_initial_means(const Mat<eT>& X, const gmm_seed_mode& seed
       }
     }
   
-  // get_stream_err2() << "generate_initial_means():" << '\n';
+  // get_cout_stream() << "generate_initial_means():" << '\n';
   // means.print();
   }
 
@@ -2128,13 +2128,13 @@ gmm_diag<eT>::km_iterate(const Mat<eT>& X, const uword max_iter, const bool verb
   
   if(verbose)
     {
-    get_stream_err2().unsetf(ios::showbase);
-    get_stream_err2().unsetf(ios::uppercase);
-    get_stream_err2().unsetf(ios::showpos);
-    get_stream_err2().unsetf(ios::scientific);
+    get_cout_stream().unsetf(ios::showbase);
+    get_cout_stream().unsetf(ios::uppercase);
+    get_cout_stream().unsetf(ios::showpos);
+    get_cout_stream().unsetf(ios::scientific);
     
-    get_stream_err2().setf(ios::right);
-    get_stream_err2().setf(ios::fixed);
+    get_cout_stream().setf(ios::right);
+    get_cout_stream().setf(ios::fixed);
     }
   
   const uword X_n_cols = X.n_cols;
@@ -2166,7 +2166,7 @@ gmm_diag<eT>::km_iterate(const Mat<eT>& X, const uword max_iter, const bool verb
     const uword n_threads = 1;
   #endif
   
-  if(verbose)  { get_stream_err2() << signature << ": n_threads: " << n_threads  << '\n'; get_stream_err2().flush(); }
+  if(verbose)  { get_cout_stream() << signature << ": n_threads: " << n_threads  << '\n'; get_cout_stream().flush(); }
   
   for(uword iter=1; iter <= max_iter; ++iter)
     {
@@ -2282,7 +2282,7 @@ gmm_diag<eT>::km_iterate(const Mat<eT>& X, const uword max_iter, const bool verb
     
     if(dead_gs.n_elem > 0)
       {
-      if(verbose)  { get_stream_err2() << signature << ": recovering from dead means\n"; get_stream_err2().flush(); }
+      if(verbose)  { get_cout_stream() << signature << ": recovering from dead means\n"; get_cout_stream().flush(); }
       
       uword* last_indx_mem = last_indx.memptr();
     
@@ -2328,16 +2328,16 @@ gmm_diag<eT>::km_iterate(const Mat<eT>& X, const uword max_iter, const bool verb
     
     if(verbose)
       {
-      get_stream_err2() << signature << ": iteration: ";
-      get_stream_err2().unsetf(ios::scientific);
-      get_stream_err2().setf(ios::fixed);
-      get_stream_err2().width(std::streamsize(4));
-      get_stream_err2() << iter;
-      get_stream_err2() << "   delta: ";
-      get_stream_err2().unsetf(ios::fixed);
-      //get_stream_err2().setf(ios::scientific);
-      get_stream_err2() << rs_delta.mean() << '\n';
-      get_stream_err2().flush();
+      get_cout_stream() << signature << ": iteration: ";
+      get_cout_stream().unsetf(ios::scientific);
+      get_cout_stream().setf(ios::fixed);
+      get_cout_stream().width(std::streamsize(4));
+      get_cout_stream() << iter;
+      get_cout_stream() << "   delta: ";
+      get_cout_stream().unsetf(ios::fixed);
+      //get_cout_stream().setf(ios::scientific);
+      get_cout_stream() << rs_delta.mean() << '\n';
+      get_cout_stream().flush();
       }
     
     arma::swap(old_means, new_means);
@@ -2369,13 +2369,13 @@ gmm_diag<eT>::em_iterate(const Mat<eT>& X, const uword max_iter, const eT var_fl
   
   if(verbose)
     {
-    get_stream_err2().unsetf(ios::showbase);
-    get_stream_err2().unsetf(ios::uppercase);
-    get_stream_err2().unsetf(ios::showpos);
-    get_stream_err2().unsetf(ios::scientific);
+    get_cout_stream().unsetf(ios::showbase);
+    get_cout_stream().unsetf(ios::uppercase);
+    get_cout_stream().unsetf(ios::showpos);
+    get_cout_stream().unsetf(ios::scientific);
     
-    get_stream_err2().setf(ios::right);
-    get_stream_err2().setf(ios::fixed);
+    get_cout_stream().setf(ios::right);
+    get_cout_stream().setf(ios::fixed);
     }
   
   const umat boundaries = internal_gen_boundaries(X.n_cols);
@@ -2402,7 +2402,7 @@ gmm_diag<eT>::em_iterate(const Mat<eT>& X, const uword max_iter, const eT var_fl
   
   if(verbose)
     {
-    get_stream_err2() << "gmm_diag::learn(): EM: n_threads: " << n_threads  << '\n';
+    get_cout_stream() << "gmm_diag::learn(): EM: n_threads: " << n_threads  << '\n';
     }
   
   eT old_avg_log_p = -Datum<eT>::inf;
@@ -2419,16 +2419,16 @@ gmm_diag<eT>::em_iterate(const Mat<eT>& X, const uword max_iter, const eT var_fl
     
     if(verbose)
       {
-      get_stream_err2() << "gmm_diag::learn(): EM: iteration: ";
-      get_stream_err2().unsetf(ios::scientific);
-      get_stream_err2().setf(ios::fixed);
-      get_stream_err2().width(std::streamsize(4));
-      get_stream_err2() << iter;
-      get_stream_err2() << "   avg_log_p: ";
-      get_stream_err2().unsetf(ios::fixed);
-      //get_stream_err2().setf(ios::scientific);
-      get_stream_err2() << new_avg_log_p << '\n';
-      get_stream_err2().flush();
+      get_cout_stream() << "gmm_diag::learn(): EM: iteration: ";
+      get_cout_stream().unsetf(ios::scientific);
+      get_cout_stream().setf(ios::fixed);
+      get_cout_stream().width(std::streamsize(4));
+      get_cout_stream() << iter;
+      get_cout_stream() << "   avg_log_p: ";
+      get_cout_stream().unsetf(ios::fixed);
+      //get_cout_stream().setf(ios::scientific);
+      get_cout_stream() << new_avg_log_p << '\n';
+      get_cout_stream().flush();
       }
     
     if(arma_isfinite(new_avg_log_p) == false)  { return false; }

--- a/inst/include/armadillo_bits/gmm_full_meat.hpp
+++ b/inst/include/armadillo_bits/gmm_full_meat.hpp
@@ -832,7 +832,7 @@ gmm_full<eT>::learn
     
     reset(X.n_rows, N_gaus);
     
-    if(print_mode)  { get_stream_err2() << "gmm_full::learn(): generating initial means\n"; get_stream_err2().flush(); }
+    if(print_mode)  { get_cout_stream() << "gmm_full::learn(): generating initial means\n"; get_cout_stream().flush(); }
     
          if(dist_mode == eucl_dist)  { generate_initial_means<1>(X, seed_mode); }
     else if(dist_mode == maha_dist)  { generate_initial_means<2>(X, seed_mode); }
@@ -843,14 +843,14 @@ gmm_full<eT>::learn
   
   if(km_iter > 0)
     {
-    const arma_ostream_state stream_state(get_stream_err2());
+    const arma_ostream_state stream_state(get_cout_stream());
     
     bool status = false;
     
          if(dist_mode == eucl_dist)  { status = km_iterate<1>(X, km_iter, print_mode); }
     else if(dist_mode == maha_dist)  { status = km_iterate<2>(X, km_iter, print_mode); }
     
-    stream_state.restore(get_stream_err2());
+    stream_state.restore(get_cout_stream());
     
     if(status == false)  { arma_debug_warn("gmm_full::learn(): k-means algorithm failed; not enough data, or too many gaussians requested"); init(orig); return false; }
     }
@@ -862,7 +862,7 @@ gmm_full<eT>::learn
   
   if(seed_mode != keep_existing)
     {
-    if(print_mode)  { get_stream_err2() << "gmm_full::learn(): generating initial covariances\n"; get_stream_err2().flush(); }
+    if(print_mode)  { get_cout_stream() << "gmm_full::learn(): generating initial covariances\n"; get_cout_stream().flush(); }
     
          if(dist_mode == eucl_dist)  { generate_initial_params<1>(X, var_floor_actual); }
     else if(dist_mode == maha_dist)  { generate_initial_params<2>(X, var_floor_actual); }
@@ -873,11 +873,11 @@ gmm_full<eT>::learn
   
   if(em_iter > 0)
     {
-    const arma_ostream_state stream_state(get_stream_err2());
+    const arma_ostream_state stream_state(get_cout_stream());
     
     const bool status = em_iterate(X, em_iter, var_floor_actual, print_mode);
     
-    stream_state.restore(get_stream_err2());
+    stream_state.restore(get_cout_stream());
     
     if(status == false)  { arma_debug_warn("gmm_full::learn(): EM algorithm failed"); init(orig); return false; }
     }
@@ -1093,7 +1093,7 @@ gmm_full<eT>::internal_gen_boundaries(const uword N) const
     static const uword n_threads = 1;
   #endif
   
-  // get_stream_err2() << "gmm_full::internal_gen_boundaries(): n_threads: " << n_threads << '\n';
+  // get_cout_stream() << "gmm_full::internal_gen_boundaries(): n_threads: " << n_threads << '\n';
   
   umat boundaries(2, n_threads);
   
@@ -1119,7 +1119,7 @@ gmm_full<eT>::internal_gen_boundaries(const uword N) const
     boundaries.zeros();
     }
   
-  // get_stream_err2() << "gmm_full::internal_gen_boundaries(): boundaries: " << '\n' << boundaries << '\n';
+  // get_cout_stream() << "gmm_full::internal_gen_boundaries(): boundaries: " << '\n' << boundaries << '\n';
   
   return boundaries;
   }
@@ -1982,7 +1982,7 @@ gmm_full<eT>::generate_initial_means(const Mat<eT>& X, const gmm_seed_mode& seed
       }
     }
   
-  // get_stream_err2() << "generate_initial_means():" << '\n';
+  // get_cout_stream() << "generate_initial_means():" << '\n';
   // means.print();
   }
 
@@ -2153,13 +2153,13 @@ gmm_full<eT>::km_iterate(const Mat<eT>& X, const uword max_iter, const bool verb
   
   if(verbose)
     {
-    get_stream_err2().unsetf(ios::showbase);
-    get_stream_err2().unsetf(ios::uppercase);
-    get_stream_err2().unsetf(ios::showpos);
-    get_stream_err2().unsetf(ios::scientific);
+    get_cout_stream().unsetf(ios::showbase);
+    get_cout_stream().unsetf(ios::uppercase);
+    get_cout_stream().unsetf(ios::showpos);
+    get_cout_stream().unsetf(ios::scientific);
     
-    get_stream_err2().setf(ios::right);
-    get_stream_err2().setf(ios::fixed);
+    get_cout_stream().setf(ios::right);
+    get_cout_stream().setf(ios::fixed);
     }
   
   const uword X_n_cols = X.n_cols;
@@ -2191,7 +2191,7 @@ gmm_full<eT>::km_iterate(const Mat<eT>& X, const uword max_iter, const bool verb
     const uword n_threads = 1;
   #endif
   
-  if(verbose)  { get_stream_err2() << "gmm_full::learn(): k-means: n_threads: " << n_threads << '\n';  get_stream_err2().flush(); }
+  if(verbose)  { get_cout_stream() << "gmm_full::learn(): k-means: n_threads: " << n_threads << '\n';  get_cout_stream().flush(); }
   
   for(uword iter=1; iter <= max_iter; ++iter)
     {
@@ -2307,7 +2307,7 @@ gmm_full<eT>::km_iterate(const Mat<eT>& X, const uword max_iter, const bool verb
     
     if(dead_gs.n_elem > 0)
       {
-      if(verbose)  { get_stream_err2() << "gmm_full::learn(): k-means: recovering from dead means\n"; get_stream_err2().flush(); }
+      if(verbose)  { get_cout_stream() << "gmm_full::learn(): k-means: recovering from dead means\n"; get_cout_stream().flush(); }
       
       uword* last_indx_mem = last_indx.memptr();
     
@@ -2353,16 +2353,16 @@ gmm_full<eT>::km_iterate(const Mat<eT>& X, const uword max_iter, const bool verb
     
     if(verbose)
       {
-      get_stream_err2() << "gmm_full::learn(): k-means: iteration: ";
-      get_stream_err2().unsetf(ios::scientific);
-      get_stream_err2().setf(ios::fixed);
-      get_stream_err2().width(std::streamsize(4));
-      get_stream_err2() << iter;
-      get_stream_err2() << "   delta: ";
-      get_stream_err2().unsetf(ios::fixed);
-      //get_stream_err2().setf(ios::scientific);
-      get_stream_err2() << rs_delta.mean() << '\n';
-      get_stream_err2().flush();
+      get_cout_stream() << "gmm_full::learn(): k-means: iteration: ";
+      get_cout_stream().unsetf(ios::scientific);
+      get_cout_stream().setf(ios::fixed);
+      get_cout_stream().width(std::streamsize(4));
+      get_cout_stream() << iter;
+      get_cout_stream() << "   delta: ";
+      get_cout_stream().unsetf(ios::fixed);
+      //get_cout_stream().setf(ios::scientific);
+      get_cout_stream() << rs_delta.mean() << '\n';
+      get_cout_stream().flush();
       }
     
     arma::swap(old_means, new_means);
@@ -2392,13 +2392,13 @@ gmm_full<eT>::em_iterate(const Mat<eT>& X, const uword max_iter, const eT var_fl
   
   if(verbose)
     {
-    get_stream_err2().unsetf(ios::showbase);
-    get_stream_err2().unsetf(ios::uppercase);
-    get_stream_err2().unsetf(ios::showpos);
-    get_stream_err2().unsetf(ios::scientific);
+    get_cout_stream().unsetf(ios::showbase);
+    get_cout_stream().unsetf(ios::uppercase);
+    get_cout_stream().unsetf(ios::showpos);
+    get_cout_stream().unsetf(ios::scientific);
     
-    get_stream_err2().setf(ios::right);
-    get_stream_err2().setf(ios::fixed);
+    get_cout_stream().setf(ios::right);
+    get_cout_stream().setf(ios::fixed);
     }
   
   const umat boundaries = internal_gen_boundaries(X.n_cols);
@@ -2425,7 +2425,7 @@ gmm_full<eT>::em_iterate(const Mat<eT>& X, const uword max_iter, const eT var_fl
   
   if(verbose)
     {
-    get_stream_err2() << "gmm_full::learn(): EM: n_threads: " << n_threads  << '\n';
+    get_cout_stream() << "gmm_full::learn(): EM: n_threads: " << n_threads  << '\n';
     }
   
   eT old_avg_log_p = -Datum<eT>::inf;
@@ -2444,16 +2444,16 @@ gmm_full<eT>::em_iterate(const Mat<eT>& X, const uword max_iter, const eT var_fl
     
     if(verbose)
       {
-      get_stream_err2() << "gmm_full::learn(): EM: iteration: ";
-      get_stream_err2().unsetf(ios::scientific);
-      get_stream_err2().setf(ios::fixed);
-      get_stream_err2().width(std::streamsize(4));
-      get_stream_err2() << iter;
-      get_stream_err2() << "   avg_log_p: ";
-      get_stream_err2().unsetf(ios::fixed);
-      //get_stream_err2().setf(ios::scientific);
-      get_stream_err2() << new_avg_log_p << '\n';
-      get_stream_err2().flush();
+      get_cout_stream() << "gmm_full::learn(): EM: iteration: ";
+      get_cout_stream().unsetf(ios::scientific);
+      get_cout_stream().setf(ios::fixed);
+      get_cout_stream().width(std::streamsize(4));
+      get_cout_stream() << iter;
+      get_cout_stream() << "   avg_log_p: ";
+      get_cout_stream().unsetf(ios::fixed);
+      //get_cout_stream().setf(ios::scientific);
+      get_cout_stream() << new_avg_log_p << '\n';
+      get_cout_stream().flush();
       }
     
     if(arma_isfinite(new_avg_log_p) == false)  { return false; }

--- a/inst/include/armadillo_bits/include_hdf5.hpp
+++ b/inst/include/armadillo_bits/include_hdf5.hpp
@@ -33,5 +33,6 @@
   #if defined(H5_USE_16_API_DEFAULT) || defined(H5_USE_16_API)
     #pragma message ("WARNING: disabling use of HDF5 due to its incompatible configuration")
     #undef ARMA_USE_HDF5
+    #undef ARMA_USE_HDF5_ALT
   #endif
 #endif

--- a/inst/include/armadillo_bits/op_chol_meat.hpp
+++ b/inst/include/armadillo_bits/op_chol_meat.hpp
@@ -30,7 +30,7 @@ op_chol::apply(Mat<typename T1::elem_type>& out, const Op<T1,op_chol>& X)
   
   if(status == false)
     {
-    out.reset();
+    out.soft_reset();
     arma_stop_runtime_error("chol(): decomposition failed");
     }
   }

--- a/inst/include/armadillo_bits/op_expmat_meat.hpp
+++ b/inst/include/armadillo_bits/op_expmat_meat.hpp
@@ -37,7 +37,7 @@ op_expmat::apply(Mat<typename T1::elem_type>& out, const Op<T1, op_expmat>& expr
   
   if(status == false)
     {
-    out.reset();
+    out.soft_reset();
     arma_stop_runtime_error("expmat(): given matrix appears ill-conditioned");
     }
   }
@@ -132,7 +132,7 @@ op_expmat_sym::apply(Mat<typename T1::elem_type>& out, const Op<T1,op_expmat_sym
   
   if(status == false)
     {
-    out.reset();
+    out.soft_reset();
     arma_stop_runtime_error("expmat_sym(): transformation failed");
     }
   }

--- a/inst/include/armadillo_bits/op_inv_meat.hpp
+++ b/inst/include/armadillo_bits/op_inv_meat.hpp
@@ -34,7 +34,7 @@ op_inv::apply(Mat<eT>& out, const Mat<eT>& A)
   
   if(status == false)
     {
-    out.reset();
+    out.soft_reset();
     arma_stop_runtime_error("inv(): matrix seems singular");
     }
   }
@@ -64,7 +64,7 @@ op_inv::apply(Mat<typename T1::elem_type>& out, const Op<T1,op_inv>& X)
     
   if(status == false)
     {
-    out.reset();
+    out.soft_reset();
     arma_stop_runtime_error("inv(): matrix seems singular");
     }
   }
@@ -134,7 +134,7 @@ op_inv_tr::apply(Mat<typename T1::elem_type>& out, const Op<T1,op_inv_tr>& X)
   
   if(status == false)
     {
-    out.reset();
+    out.soft_reset();
     arma_stop_runtime_error("inv(): matrix seems singular");
     }
   }
@@ -153,7 +153,7 @@ op_inv_sympd::apply(Mat<typename T1::elem_type>& out, const Op<T1,op_inv_sympd>&
   
   if(status == false)
     {
-    out.reset();
+    out.soft_reset();
     arma_stop_runtime_error("inv_sympd(): matrix is singular or not positive definite");
     }
   }

--- a/inst/include/armadillo_bits/op_logmat_meat.hpp
+++ b/inst/include/armadillo_bits/op_logmat_meat.hpp
@@ -36,7 +36,7 @@ op_logmat::apply(Mat< std::complex<typename T1::elem_type> >& out, const mtOp<st
   
   if(status == false)
     {
-    out.reset();
+    out.soft_reset();
     arma_stop_runtime_error("logmat(): transformation failed");
     }
   }
@@ -136,7 +136,7 @@ op_logmat_cx::apply(Mat<typename T1::elem_type>& out, const Op<T1,op_logmat_cx>&
   
   if(status == false)
     {
-    out.reset();
+    out.soft_reset();
     arma_stop_runtime_error("logmat(): transformation failed");
     }
   }
@@ -363,7 +363,7 @@ op_logmat_sympd::apply(Mat<typename T1::elem_type>& out, const Op<T1,op_logmat_s
   
   if(status == false)
     {
-    out.reset();
+    out.soft_reset();
     arma_stop_runtime_error("logmat_sympd(): transformation failed");
     }
   }

--- a/inst/include/armadillo_bits/op_orth_null_meat.hpp
+++ b/inst/include/armadillo_bits/op_orth_null_meat.hpp
@@ -64,7 +64,7 @@ op_orth::apply_direct(Mat<typename T1::elem_type>& out, const Base<typename T1::
   
   V.reset();
   
-  if(status == false)  { out.reset(); return false; }
+  if(status == false)  { out.soft_reset(); return false; }
   
   if(s.is_empty())  { out.reset(); return true; }
   
@@ -140,7 +140,7 @@ op_null::apply_direct(Mat<typename T1::elem_type>& out, const Base<typename T1::
   
   U.reset();
   
-  if(status == false)  { out.reset(); return false; }
+  if(status == false)  { out.soft_reset(); return false; }
   
   if(s.is_empty())  { out.reset(); return true; }
   

--- a/inst/include/armadillo_bits/op_pinv_meat.hpp
+++ b/inst/include/armadillo_bits/op_pinv_meat.hpp
@@ -85,7 +85,7 @@ op_pinv::apply_direct(Mat<typename T1::elem_type>& out, const Base<typename T1::
   
   if(status == false)
     {
-    out.reset();
+    out.soft_reset();
     return false;
     }
   

--- a/inst/include/armadillo_bits/op_princomp_meat.hpp
+++ b/inst/include/armadillo_bits/op_princomp_meat.hpp
@@ -605,7 +605,7 @@ op_princomp::apply
   
   if(status == false)
     {
-    out.reset();
+    out.soft_reset();
     
     arma_stop_runtime_error("princomp(): decomposition failed");
     }

--- a/inst/include/armadillo_bits/op_sort_index_meat.hpp
+++ b/inst/include/armadillo_bits/op_sort_index_meat.hpp
@@ -40,7 +40,7 @@ arma_sort_index_helper(Mat<uword>& out, const Proxy<T1>& P, const uword sort_typ
       {
       const eT val = P[i];
       
-      if(arma_isnan(val))  { out.reset(); return false; }
+      if(arma_isnan(val))  { out.soft_reset(); return false; }
       
       packet_vec[i].val   = val;
       packet_vec[i].index = i;
@@ -58,7 +58,7 @@ arma_sort_index_helper(Mat<uword>& out, const Proxy<T1>& P, const uword sort_typ
       {
       const eT val = P.at(row,col);
       
-      if(arma_isnan(val))  { out.reset(); return false; }
+      if(arma_isnan(val))  { out.soft_reset(); return false; }
       
       packet_vec[i].val   = val;
       packet_vec[i].index = i;

--- a/inst/include/armadillo_bits/op_sqrtmat_meat.hpp
+++ b/inst/include/armadillo_bits/op_sqrtmat_meat.hpp
@@ -123,7 +123,7 @@ op_sqrtmat::apply_direct(Mat< std::complex<typename T1::elem_type> >& out, const
   if(schur_ok == false)
     {
     arma_extra_debug_print("sqrtmat(): schur decomposition failed");
-    out.reset();
+    out.soft_reset();
     return false;
     }
   
@@ -246,7 +246,7 @@ op_sqrtmat_cx::apply_direct(Mat<typename T1::elem_type>& out, const Base<typenam
   if(schur_ok == false)
     {
     arma_extra_debug_print("sqrtmat(): schur decomposition failed");
-    out.reset();
+    out.soft_reset();
     return false;
     }
   
@@ -324,7 +324,7 @@ op_sqrtmat_sympd::apply(Mat<typename T1::elem_type>& out, const Op<T1,op_sqrtmat
   
   if(status == false)
     {
-    out.reset();
+    out.soft_reset();
     arma_stop_runtime_error("sqrtmat_sympd(): transformation failed");
     }
   }

--- a/inst/include/armadillo_bits/op_sum_meat.hpp
+++ b/inst/include/armadillo_bits/op_sum_meat.hpp
@@ -240,6 +240,12 @@ op_sum::apply_noalias_proxy_mp(Mat<typename T1::elem_type>& out, const Proxy<T1>
         }
       }
     }
+  #else
+    {
+    arma_ignore(out);
+    arma_ignore(P);
+    arma_ignore(dim);
+    }
   #endif
   }
 
@@ -559,6 +565,12 @@ op_sum::apply_noalias_proxy_mp(Cube<typename T1::elem_type>& out, const ProxyCub
           }
         }
       }
+    }
+  #else
+    {
+    arma_ignore(out);
+    arma_ignore(P);
+    arma_ignore(dim);
     }
   #endif
   }

--- a/inst/include/armadillo_bits/op_unique_meat.hpp
+++ b/inst/include/armadillo_bits/op_unique_meat.hpp
@@ -58,7 +58,7 @@ op_unique::apply_helper(Mat<typename T1::elem_type>& out, const Proxy<T1>& P)
       {
       const eT val = Pea[i];
       
-      if(arma_isnan(val))  { out.reset(); return false; }
+      if(arma_isnan(val))  { out.soft_reset(); return false; }
       
       X_mem[i] = val;
       }
@@ -70,7 +70,7 @@ op_unique::apply_helper(Mat<typename T1::elem_type>& out, const Proxy<T1>& P)
       {
       const eT val = P.at(row,col);
       
-      if(arma_isnan(val))  { out.reset(); return false; }
+      if(arma_isnan(val))  { out.soft_reset(); return false; }
       
       (*X_mem) = val;  X_mem++;
       }

--- a/inst/include/armadillo_bits/operator_ostream.hpp
+++ b/inst/include/armadillo_bits/operator_ostream.hpp
@@ -67,6 +67,48 @@ operator<< (std::ostream& o, const SpValProxy<T1>& X)
 
 
 
+template<typename eT>
+inline
+std::ostream&
+operator<< (std::ostream& o, const MapMat_val<eT>& X)
+  {
+  arma_extra_debug_sigprint();
+  
+  o << eT(X);
+  
+  return o;
+  }
+
+
+
+template<typename eT>
+inline
+std::ostream&
+operator<< (std::ostream& o, const MapMat_elem<eT>& X)
+  {
+  arma_extra_debug_sigprint();
+  
+  o << eT(X);
+  
+  return o;
+  }
+
+
+
+template<typename eT>
+inline
+std::ostream&
+operator<< (std::ostream& o, const MapMat_svel<eT>& X)
+  {
+  arma_extra_debug_sigprint();
+  
+  o << eT(X);
+  
+  return o;
+  }
+
+
+
 template<typename T1>
 inline
 std::ostream&

--- a/inst/include/armadillo_bits/sp_auxlib_meat.hpp
+++ b/inst/include/armadillo_bits/sp_auxlib_meat.hpp
@@ -744,13 +744,13 @@ sp_auxlib::spsolve_simple(Mat<typename T1::elem_type>& X, const SpBase<typename 
     if(A.n_rows > A.n_cols)
       {
       arma_stop_logic_error("spsolve(): solving over-determined systems currently not supported");
-      X.reset();
+      X.soft_reset();
       return false;
       }
     else if(A.n_rows < A.n_cols)
       {
       arma_stop_logic_error("spsolve(): solving under-determined systems currently not supported");
-      X.reset();
+      X.soft_reset();
       return false;
       }
     
@@ -789,7 +789,7 @@ sp_auxlib::spsolve_simple(Mat<typename T1::elem_type>& X, const SpBase<typename 
       {
       destroy_supermatrix(a);
       destroy_supermatrix(x);
-      X.reset();
+      X.soft_reset();
       return false;
       }
     
@@ -890,13 +890,13 @@ sp_auxlib::spsolve_refine(Mat<typename T1::elem_type>& X, typename T1::pod_type&
     if(A.n_rows > A.n_cols)
       {
       arma_stop_logic_error("spsolve(): solving over-determined systems currently not supported");
-      X.reset();
+      X.soft_reset();
       return false;
       }
     else if(A.n_rows < A.n_cols)
       {
       arma_stop_logic_error("spsolve(): solving under-determined systems currently not supported");
-      X.reset();
+      X.soft_reset();
       return false;
       }
     
@@ -941,7 +941,7 @@ sp_auxlib::spsolve_refine(Mat<typename T1::elem_type>& X, typename T1::pod_type&
       destroy_supermatrix(x);
       destroy_supermatrix(a);
       destroy_supermatrix(b);
-      X.reset();
+      X.soft_reset();
       return false;
       }
     

--- a/inst/include/armadillo_bits/spdiagview_bones.hpp
+++ b/inst/include/armadillo_bits/spdiagview_bones.hpp
@@ -20,7 +20,7 @@
 
 //! Class for storing data required to extract and set the diagonals of a sparse matrix
 template<typename eT>
-class spdiagview : public Base<eT, spdiagview<eT> >
+class spdiagview : public SpBase<eT, spdiagview<eT> >
   {
   public:
   
@@ -69,22 +69,20 @@ class spdiagview : public Base<eT, spdiagview<eT> >
   template<typename T1> inline void operator%=(const SpBase<eT,T1>& x);
   template<typename T1> inline void operator/=(const SpBase<eT,T1>& x);
   
-  inline eT                      at_alt    (const uword ii) const;
+  inline MapMat_elem<eT> operator[](const uword ii);
+  inline eT              operator[](const uword ii) const;
   
-  inline SpValProxy< SpMat<eT> > operator[](const uword ii);
-  inline eT                      operator[](const uword ii) const;
+  inline MapMat_elem<eT> at(const uword ii);
+  inline eT              at(const uword ii) const;
   
-  inline SpValProxy< SpMat<eT> >         at(const uword ii);
-  inline eT                              at(const uword ii) const;
+  inline MapMat_elem<eT> operator()(const uword ii);
+  inline eT              operator()(const uword ii) const;
   
-  inline SpValProxy< SpMat<eT> > operator()(const uword ii);
-  inline eT                      operator()(const uword ii) const;
+  inline MapMat_elem<eT> at(const uword in_n_row, const uword);
+  inline eT              at(const uword in_n_row, const uword) const;
   
-  inline SpValProxy< SpMat<eT> >         at(const uword in_n_row, const uword);
-  inline eT                              at(const uword in_n_row, const uword) const;
-  
-  inline SpValProxy< SpMat<eT> > operator()(const uword in_n_row, const uword in_n_col);
-  inline eT                      operator()(const uword in_n_row, const uword in_n_col) const;
+  inline MapMat_elem<eT> operator()(const uword in_n_row, const uword in_n_col);
+  inline eT              operator()(const uword in_n_row, const uword in_n_col) const;
   
   
   inline void fill(const eT val);
@@ -92,8 +90,10 @@ class spdiagview : public Base<eT, spdiagview<eT> >
   inline void ones();
   inline void randu();
   inline void randn();
-    
-  inline static void extract(Mat<eT>& out, const spdiagview& in);
+  
+  
+  inline static void extract(SpMat<eT>& out, const spdiagview& in);
+  inline static void extract(  Mat<eT>& out, const spdiagview& in);
   
   
   private:

--- a/inst/include/armadillo_bits/subview_field_meat.hpp
+++ b/inst/include/armadillo_bits/subview_field_meat.hpp
@@ -412,14 +412,14 @@ subview_field<oT>::print(const std::string extra_text) const
   
   if(extra_text.length() != 0)
     {
-    const std::streamsize orig_width = ARMA_DEFAULT_OSTREAM.width();
+    const std::streamsize orig_width = get_cout_stream().width();
     
-    ARMA_DEFAULT_OSTREAM << extra_text << '\n';
-  
-    ARMA_DEFAULT_OSTREAM.width(orig_width);
+    get_cout_stream() << extra_text << '\n';
+    
+    get_cout_stream().width(orig_width);
     }
   
-  arma_ostream::print(ARMA_DEFAULT_OSTREAM, *this);
+  arma_ostream::print(get_cout_stream(), *this);
   }
 
 
@@ -436,7 +436,7 @@ subview_field<oT>::print(std::ostream& user_stream, const std::string extra_text
     const std::streamsize orig_width = user_stream.width();
     
     user_stream << extra_text << '\n';
-  
+    
     user_stream.width(orig_width);
     }
   

--- a/inst/include/armadillo_bits/traits.hpp
+++ b/inst/include/armadillo_bits/traits.hpp
@@ -741,6 +741,15 @@ struct is_SpSubview< SpSubview<eT> >
 
 
 template<typename T>
+struct is_spdiagview
+  { static const bool value = false; };
+
+template<typename eT>
+struct is_spdiagview< spdiagview<eT> >
+  { static const bool value = true; };
+
+
+template<typename T>
 struct is_SpOp
   { static const bool value = false; };
  
@@ -774,6 +783,7 @@ struct is_arma_sparse_type
   static const bool value
   =  is_SpMat<T1>::value
   || is_SpSubview<T1>::value
+  || is_spdiagview<T1>::value
   || is_SpOp<T1>::value
   || is_SpGlue<T1>::value
   || is_mtSpOp<T1>::value

--- a/inst/include/armadillo_bits/typedef_mat.hpp
+++ b/inst/include/armadillo_bits/typedef_mat.hpp
@@ -141,4 +141,16 @@ typedef SpCol <cx_double> sp_cx_colvec;
 typedef SpRow <cx_double> sp_cx_rowvec;
 
 
+// internal use only; subject to change and/or removal without notice
+typedef MapMat <uword>     map_umat;
+typedef MapMat <sword>     map_imat;
+typedef MapMat <float>     map_fmat;
+typedef MapMat <double>    map_dmat;
+typedef MapMat <double>    map_mat;
+typedef MapMat <cx_float>  map_cx_fmat;
+typedef MapMat <cx_double> map_cx_dmat;
+typedef MapMat <cx_double> map_cx_mat;
+
+
+
 //! @}

--- a/inst/include/armadillo_bits/unwrap.hpp
+++ b/inst/include/armadillo_bits/unwrap.hpp
@@ -204,7 +204,7 @@ struct quasi_unwrap_fixed
     arma_extra_debug_sigprint();
     }
   
-  const Mat<eT>& M;
+  const T1& M;
   
   template<typename eT2>
   arma_inline bool is_alias(const Mat<eT2>& X) const { return (void_ptr(&M) == void_ptr(&X)); }

--- a/inst/include/armadillo_bits/unwrap_spmat.hpp
+++ b/inst/include/armadillo_bits/unwrap_spmat.hpp
@@ -48,6 +48,8 @@ struct unwrap_spmat< SpMat<eT> >
     : M(A)
     {
     arma_extra_debug_sigprint();
+    
+    M.sync();
     }
   
   const SpMat<eT>& M;
@@ -65,6 +67,8 @@ struct unwrap_spmat< SpRow<eT> >
     : M(A)
     {
     arma_extra_debug_sigprint();
+    
+    M.sync();
     }
   
   const SpRow<eT>& M;
@@ -82,6 +86,8 @@ struct unwrap_spmat< SpCol<eT> >
     : M(A)
     {
     arma_extra_debug_sigprint();
+    
+    M.sync();
     }
   
   const SpCol<eT>& M;


### PR DESCRIPTION
I just call .sync() in as<>() and it works. But it seems a little weird that no error comes out when I don't call .sync() in wrap() before reading those internal arrays of the SpMat class. 