### PR TITLE
conversion of simple_triplet_matrix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: RcppArmadillo
 Type: Package
 Title: 'Rcpp' Integration for the 'Armadillo' Templated Linear Algebra Library
-Version: 0.8.300.0.0
+Version: 0.8.300.0.1
 Date: 2017-11-22
 Author: Dirk Eddelbuettel, Romain Francois, Doug Bates and Binxiang Ni
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/inst/include/RcppArmadilloAs.h
+++ b/inst/include/RcppArmadilloAs.h
@@ -83,7 +83,19 @@ namespace traits {
     template <typename T>
     class Exporter< arma::SpMat<T> > {
     public:
-        Exporter( SEXP x ) : mat(x){}
+        Exporter( SEXP x ) {
+            if (Rf_inherits(x, "simple_triplet_matrix")) {
+                List li = x;
+                mat = S4("dgTMatrix");
+                mat.slot("i") = as<NumericVector>(li["i"]) - 1;
+                mat.slot("j") = as<NumericVector>(li["j"]) - 1;
+                mat.slot("x") = li["v"];
+                mat.slot("Dim") = IntegerVector::create(li["nrow"], li["ncol"]);
+            }
+            else {
+                mat = x;
+            }
+        }
                 
         arma::SpMat<T> get(){
             const int  RTYPE = Rcpp::traits::r_sexptype_traits<T>::rtype;

--- a/inst/unitTests/runit.sparseConversion.R
+++ b/inst/unitTests/runit.sparseConversion.R
@@ -672,6 +672,14 @@ if (.runThisTest) {
         ind <- p10[1:3, ]
         dgc <- as(as(ind, "matrix"), "dgCMatrix")
         checkEquals(dgc, asSpMat(ind), msg="ind2dgC_9")
+    } 
+    if (suppressMessages(require(slam))) {
+        test.as.stm2dgc <- function() {
+            ## simple_triplet_matrix from package slam
+            stm <- as.simple_triplet_matrix(diag(2))
+            dgc <- as(as(stm, "matrix"), "dgCMatrix")
+            checkEquals(dgc, asSpMat(stm), msg="stm2dgc")
+        }
     }
 
     test.stop <- function() {


### PR DESCRIPTION
A small patch adding conversion of simple_triplet_matrix format from package slam.
Sorry for all these white spaces removing, it's my new editor Atom who's responsible.
If it's too annoying for you, I'll try to disable this feature and submit with only pertinent part of
modifications.