### PR TITLE
add warning for nonstandard macOS builds

### DIFF
--- a/R/SciPy2R.R
+++ b/R/SciPy2R.R
@@ -25,11 +25,16 @@
     type <- spmat$getformat()
     shape <- unlist(spmat$shape)
     data <- as.vector(reticulate::py_get_attr(spmat, "data"))
-    if (type == "csc") {
-        indices <- as.vector(reticulate::py_get_attr(spmat, "indices"))
-        indptr <- as.vector(reticulate::py_get_attr(spmat, "indptr"))
-        res <- new("dgCMatrix", i = indices, p = indptr, x = data, Dim = shape)
-    } else if (type == "coo") {
+    
+    # Since CSC Matrix from SciPy has been automatically converted to dgCMatrix, 
+    # the conversion for csc matrix is no longer needed.
+    
+    # if (type == "csc") {
+    #     indices <- as.vector(reticulate::py_get_attr(spmat, "indices"))
+    #     indptr <- as.vector(reticulate::py_get_attr(spmat, "indptr"))
+    #     res <- new("dgCMatrix", i = indices, p = indptr, x = data, Dim = shape)
+    # } 
+    if (type == "coo") {
         row <- as.vector(reticulate::py_get_attr(spmat, "row"))
         col <- as.vector(reticulate::py_get_attr(spmat, "col"))
         res <- new("dgTMatrix", i = row, j = col, x = data, Dim = shape)

--- a/configure
+++ b/configure
@@ -613,7 +613,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -685,7 +684,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -938,15 +936,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1084,7 +1073,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1237,7 +1226,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1788,6 +1776,8 @@ fi
 ## Use R to set CXX and CXXFLAGS
 CXX=$(${R_HOME}/bin/R CMD config CXX)
 CXXFLAGS=$("${R_HOME}/bin/R" CMD config CXXFLAGS)
+
+CXX=g++-mp-7
 
 ## We are using C++
 ac_ext=cpp
@@ -2761,33 +2751,36 @@ $as_echo "$as_me: WARNING: OpenMP unavailable and turned off." >&2;}
     else
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
 $as_echo "not found" >&6; }
-        if test x"${can_use_openmp}" == x"no"; then
-            { $as_echo "$as_me:${as_lineno-$LINENO}: checking for clang compiler" >&5
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for clang compiler" >&5
 $as_echo_n "checking for clang compiler... " >&6; }
-            clang_compiler=$($CXX --version 2>&1 | grep -i -c -e 'clang ')
+        clang_compiler=$($CXX --version 2>&1 | grep -i -c -e 'clang ')
 
-            if test x"${clang_compiler}" == x"1"; then
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: found" >&5
+        if test x"${clang_compiler}" == x"1"; then
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: found" >&5
 $as_echo "found" >&6; }
-                { $as_echo "$as_me:${as_lineno-$LINENO}: checking for OpenMP compatible version of clang" >&5
+            { $as_echo "$as_me:${as_lineno-$LINENO}: checking for OpenMP compatible version of clang" >&5
 $as_echo_n "checking for OpenMP compatible version of clang... " >&6; }
-                clang_version=$(${CXX} -v 2>&1 | awk '/^.*clang version/ {print $3}')
+            clang_version=$(${CXX} -v 2>&1 | awk '/^.*clang version/ {print $3}')
 
-                case ${clang_version} in
-                    4.*|5.*|6.*|7.*|8.*)
-                        { $as_echo "$as_me:${as_lineno-$LINENO}: result: found and suitable" >&5
+            case ${clang_version} in
+                4.*|5.*|6.*|7.*|8.*)
+                    { $as_echo "$as_me:${as_lineno-$LINENO}: result: found and suitable" >&5
 $as_echo "found and suitable" >&6; }
-                        can_use_openmp="yes"
-                    ;;
-                    *)
-                        { $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
+                    can_use_openmp="yes"
+                ;;
+                *)
+                    { $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
 $as_echo "not found" >&6; }
-                        { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: OpenMP unavailable and turned off." >&5
+                    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: OpenMP unavailable and turned off." >&5
 $as_echo "$as_me: WARNING: OpenMP unavailable and turned off." >&2;}
-                        can_use_openmp="no"
-                    ;;
-                esac
-            fi
+                    can_use_openmp="no"
+                ;;
+            esac
+        else
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
+$as_echo "not found" >&6; }
+            { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: unsupported macOS build detected; if anything breaks, you keep the pieces." >&5
+$as_echo "$as_me: WARNING: unsupported macOS build detected; if anything breaks, you keep the pieces." >&2;}
         fi
     fi
 fi

--- a/configure
+++ b/configure
@@ -1777,8 +1777,6 @@ fi
 CXX=$(${R_HOME}/bin/R CMD config CXX)
 CXXFLAGS=$("${R_HOME}/bin/R" CMD config CXXFLAGS)
 
-CXX=g++-mp-7
-
 ## We are using C++
 ac_ext=cpp
 ac_cpp='$CXXCPP $CPPFLAGS'

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@
 AC_PREREQ(2.61)
 
 ## Process this file with autoconf to produce a configure script.
-AC_INIT(RcppArmadillo, m4_esyscmgd_s([awk -e '/^Version:/ {print $2}' DESCRIPTION]))
+AC_INIT(RcppArmadillo, m4_esyscmd_s([awk -e '/^Version:/ {print $2}' DESCRIPTION]))
 
 ## Set R_HOME, respecting an environment variable if one is set 
 : ${R_HOME=$(R RHOME)}
@@ -79,27 +79,28 @@ if test x"${RSysinfoName}" == x"Darwin"; then
         can_use_openmp="no"
     else
         AC_MSG_RESULT([not found])
-        if test x"${can_use_openmp}" == x"no"; then
-            AC_MSG_CHECKING([for clang compiler])
-            clang_compiler=$($CXX --version 2>&1 | grep -i -c -e 'clang ')
+        AC_MSG_CHECKING([for clang compiler])
+        clang_compiler=$($CXX --version 2>&1 | grep -i -c -e 'clang ')
 
-            if test x"${clang_compiler}" == x"1"; then
-                AC_MSG_RESULT([found])
-                AC_MSG_CHECKING([for OpenMP compatible version of clang])
-                clang_version=$(${CXX} -v 2>&1 | awk '/^.*clang version/ {print $3}')
+        if test x"${clang_compiler}" == x"1"; then
+            AC_MSG_RESULT([found])
+            AC_MSG_CHECKING([for OpenMP compatible version of clang])
+            clang_version=$(${CXX} -v 2>&1 | awk '/^.*clang version/ {print $3}')
 
-                case ${clang_version} in
-                    4.*|5.*|6.*|7.*|8.*)
-                        AC_MSG_RESULT([found and suitable])
-                        can_use_openmp="yes"
-                    ;;
-                    *)
-                        AC_MSG_RESULT([not found])
-                        AC_MSG_WARN([OpenMP unavailable and turned off.])
-                        can_use_openmp="no"
-                    ;;
-                esac
-            fi
+            case ${clang_version} in
+                4.*|5.*|6.*|7.*|8.*)
+                    AC_MSG_RESULT([found and suitable])
+                    can_use_openmp="yes"
+                ;;
+                *)
+                    AC_MSG_RESULT([not found])
+                    AC_MSG_WARN([OpenMP unavailable and turned off.])
+                    can_use_openmp="no"
+                ;;
+            esac
+        else
+            AC_MSG_RESULT([not found])
+            AC_MSG_WARN([unsupported macOS build detected; if anything breaks, you keep the pieces.])
         fi
     fi
 fi

--- a/inst/unitTests/runit.scipy2r.R
+++ b/inst/unitTests/runit.scipy2r.R
@@ -38,11 +38,14 @@ if (.runThisTest) {
                   "2 3 6")
         M <- as.matrix(read.table(text=mtxt))
         dimnames(M) <- NULL
-
+        
+        # Since 'reticulate' automatically converts CSC matrix to dgCMatrix, 
+        # no need to convert it in RcppArmadillo
+        
         test.csc2dgc <- function() {
             csc <- sp$csc_matrix(mat)
             dgC <- methods::as(M, "dgCMatrix")
-            checkEquals(dgC, RcppArmadillo:::.SciPy2R(csc), msg="csc2dgc")
+            checkEquals(dgC, csc, msg="csc2dgc")
         }
 
         test.coo2dgt <- function() {


### PR DESCRIPTION
Addresses #224. On a macOS system using gcc7:
```
* installing *source* package ‘RcppArmadillo’ ...
checking whether the C++ compiler works... yes
checking for C++ compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C++ compiler... yes
checking whether g++-mp-7 accepts -g... yes
checking how to run the C++ preprocessor... g++-mp-7 -E
checking whether we are using the GNU C++ compiler... (cached) yes
checking whether g++-mp-7 accepts -g... (cached) yes
checking whether g++ version is sufficient... yes, with OpenMP as version 7.3.0
checking for macOS... found
checking for macOS Apple compiler... not found
checking for clang compiler... not found
configure: WARNING: unsupported macOS build detected; if anything breaks, you keep the pieces.
checking LAPACK_LIBS... system LAPACK found
checking for OpenMP... found and suitable
configure: creating ./config.status
config.status: creating inst/include/RcppArmadilloConfigGenerated.h
config.status: creating src/Makevars
```
I also reverted a change to the m4 macro used on line 15 (`m4_esyscmgd_s`), was that an error? My version of autoconf complained...