### PR TITLE
Fixes #229

### DIFF
--- a/R/RcppArmadillo.package.skeleton.R
+++ b/R/RcppArmadillo.package.skeleton.R
@@ -37,13 +37,16 @@ RcppArmadillo.package.skeleton <- function(name="anRpackage", list=character(),
     skelFunName <- ifelse(haveKitten, "kitten", "package.skeleton")
     message("\nCalling ", skelFunName, " to create basic package.")
 
+    
+    
+    
     ## first let the traditional version (or the kitten alternate) do its business
     call <- match.call()
     call[[1]] <- skelFunUsed
+    if ("example_code" %in% names(call)){
+        call[["example_code"]] <- NULL	# remove the example_code argument
+    }
     if (! haveKitten) {                 # in the package.skeleton() case
-        if ("example_code" %in% names(call)){
-            call[["example_code"]] <- NULL	# remove the example_code argument
-        }
         if (fake) {
             call[["list"]] <- "Rcpp.fake.fun"
         }

--- a/R/RcppArmadillo.package.skeleton.R
+++ b/R/RcppArmadillo.package.skeleton.R
@@ -37,9 +37,6 @@ RcppArmadillo.package.skeleton <- function(name="anRpackage", list=character(),
     skelFunName <- ifelse(haveKitten, "kitten", "package.skeleton")
     message("\nCalling ", skelFunName, " to create basic package.")
 
-    
-    
-    
     ## first let the traditional version (or the kitten alternate) do its business
     call <- match.call()
     call[[1]] <- skelFunUsed


### PR DESCRIPTION
Enable use of `example_code = FALSE` argument in `RcppArmadillo.package.skeleton()` when `pkgKitten` is installed. 