### PR TITLE
Portability fixes for configure

### DIFF
--- a/configure
+++ b/configure
@@ -2744,7 +2744,7 @@ fi
 $as_echo_n "checking for macOS... " >&6; }
 RSysinfoName=$("${R_HOME}/bin/Rscript" --vanilla -e 'cat(Sys.info()["sysname"])')
 
-if test x"${RSysinfoName}" == x"Darwin"; then
+if test x"${RSysinfoName}" = x"Darwin"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: found" >&5
 $as_echo "found" >&6; }
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for macOS Apple compiler" >&5
@@ -2752,7 +2752,7 @@ $as_echo_n "checking for macOS Apple compiler... " >&6; }
 
     apple_compiler=$($CXX --version 2>&1 | grep -i -c -e 'apple llvm')
 
-    if test x"${apple_compiler}" == x"1"; then
+    if test x"${apple_compiler}" = x"1"; then
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: found" >&5
 $as_echo "found" >&6; }
         { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: OpenMP unavailable and turned off." >&5
@@ -2765,7 +2765,7 @@ $as_echo "not found" >&6; }
 $as_echo_n "checking for clang compiler... " >&6; }
         clang_compiler=$($CXX --version 2>&1 | grep -i -c -e 'clang ')
 
-        if test x"${clang_compiler}" == x"1"; then
+        if test x"${clang_compiler}" = x"1"; then
             { $as_echo "$as_me:${as_lineno-$LINENO}: result: found" >&5
 $as_echo "found" >&6; }
             { $as_echo "$as_me:${as_lineno-$LINENO}: checking for OpenMP compatible version of clang" >&5
@@ -2807,7 +2807,7 @@ hasRlapack=$(echo ${lapack} | grep lRlapack)
 ## while this may seem a little unusual we do it to fully reproduce the
 ## previous bash-based implementation
 
-if test x"${hasRlapack}" == x""; then
+if test x"${hasRlapack}" = x""; then
     ## We are using a full Lapack and can use zgbsv -- so #undef remains
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: system LAPACK found" >&5
 $as_echo "system LAPACK found" >&6; }
@@ -2827,13 +2827,13 @@ openmp_flag=""
 ## Set the fallback, by default it is nope
 arma_have_openmp="#define ARMA_DONT_USE_OPENMP 1"
 
-if test x"${can_use_openmp}" == x"yes"; then
+if test x"${can_use_openmp}" = x"yes"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for OpenMP" >&5
 $as_echo_n "checking for OpenMP... " >&6; }
     ## if R has -fopenmp we should be good
     allldflags=$(${R_HOME}/bin/R CMD config --ldflags)
     hasOpenMP=$(echo ${allldflags} | grep -- -fopenmp)
-    if test x"${hasOpenMP}" == x""; then
+    if test x"${hasOpenMP}" = x""; then
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: missing" >&5
 $as_echo "missing" >&6; }
         arma_have_openmp="#define ARMA_DONT_USE_OPENMP 1"

--- a/configure.ac
+++ b/configure.ac
@@ -67,13 +67,13 @@ fi
 AC_MSG_CHECKING([for macOS])
 RSysinfoName=$("${R_HOME}/bin/Rscript" --vanilla -e 'cat(Sys.info()[["sysname"]])')
 
-if test x"${RSysinfoName}" == x"Darwin"; then
+if test x"${RSysinfoName}" = x"Darwin"; then
     AC_MSG_RESULT([found])
     AC_MSG_CHECKING([for macOS Apple compiler])
 
     apple_compiler=$($CXX --version 2>&1 | grep -i -c -e 'apple llvm')
 
-    if test x"${apple_compiler}" == x"1"; then
+    if test x"${apple_compiler}" = x"1"; then
         AC_MSG_RESULT([found])
         AC_MSG_WARN([OpenMP unavailable and turned off.])
         can_use_openmp="no"
@@ -82,7 +82,7 @@ if test x"${RSysinfoName}" == x"Darwin"; then
         AC_MSG_CHECKING([for clang compiler])
         clang_compiler=$($CXX --version 2>&1 | grep -i -c -e 'clang ')
 
-        if test x"${clang_compiler}" == x"1"; then
+        if test x"${clang_compiler}" = x"1"; then
             AC_MSG_RESULT([found])
             AC_MSG_CHECKING([for OpenMP compatible version of clang])
             clang_version=$(${CXX} -v 2>&1 | awk '/^.*clang version/ {print $3}')
@@ -116,7 +116,7 @@ hasRlapack=$(echo ${lapack} | grep lRlapack)
 ## while this may seem a little unusual we do it to fully reproduce the
 ## previous bash-based implementation
 
-if test x"${hasRlapack}" == x""; then
+if test x"${hasRlapack}" = x""; then
     ## We are using a full Lapack and can use zgbsv -- so #undef remains
     AC_MSG_RESULT([system LAPACK found])
     arma_lapack="#undef ARMA_CRIPPLED_LAPACK"
@@ -133,12 +133,12 @@ openmp_flag=""
 ## Set the fallback, by default it is nope
 arma_have_openmp="#define ARMA_DONT_USE_OPENMP 1"
 
-if test x"${can_use_openmp}" == x"yes"; then
+if test x"${can_use_openmp}" = x"yes"; then
     AC_MSG_CHECKING([for OpenMP])
     ## if R has -fopenmp we should be good
     allldflags=$(${R_HOME}/bin/R CMD config --ldflags)
     hasOpenMP=$(echo ${allldflags} | grep -- -fopenmp)
-    if test x"${hasOpenMP}" == x""; then
+    if test x"${hasOpenMP}" = x""; then
         AC_MSG_RESULT([missing])
         arma_have_openmp="#define ARMA_DONT_USE_OPENMP 1"
     else


### PR DESCRIPTION
The `test` command, as well as the `[` command, is not required to
know the `==` operator. Only a few implementations like bash and some
versions of ksh support it.

When you run `test foo == foo` on a platform that does not support the
`==` operator, the result will be false instead of true. This can lead
to unexpected behavior.