### PR TITLE
Update Makevars.in

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,7 +1,7 @@
 ## -*- mode: makefile; -*-
 
 PKG_CXXFLAGS = -I../inst/include @OPENMP_FLAG@
-PKG_LIBS= @OPENMP_FLAG@ $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
+PKG_LIBS= $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
 
 ## With R 3.1.0 or later, you can uncomment the following line to tell R to 
 ## enable compilation with C++11 (where available)


### PR DESCRIPTION
Remove spurious flag where libs should be.

Compiles just fine on my machine without extra use of flag. I believe Makevars.win should also be changed in the same fashion, however I don't have a windows machine to test it out.