### PR TITLE
use quotes instead of angle brackets to include armadillo header

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2020-10-24  Condrad Sanderson  <conradsnicta@users.noreply.github.com>
+
+	* inst/include/RcppArmadilloForward.h: Switch to quoted #include
+
 2020-10-21  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/inst/include/RcppArmadilloForward.h
+++ b/inst/include/RcppArmadilloForward.h
@@ -46,7 +46,7 @@
 // workaround to mitigate possible interference from a system-level installation of Armadillo
 #define ARMA_DONT_USE_WRAPPER
 
-#include <armadillo>
+#include "armadillo"
 
 /* forward declarations */
 namespace Rcpp {


### PR DESCRIPTION
Related to bug https://github.com/RcppCore/RcppArmadillo/issues/314

change `#include <armadillo>` to `#include "armadillo"`
