### PR TITLE
Fix the unit test error from converting ddi matrix to dgC matrix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2020-12-30  Binxiang Ni  <binxiangni@gmail.com>
+
+	* inst/tinytest/test_sparseConversion.R: Coerce dtCMatrix to dgCMatrix in one unit test
+
 2020-11-15  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): RcppArmadillo 0.10.1.2.0

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -15,7 +15,7 @@ armadillo_version <- function(single) {
 }
 
 #' Set the Armadillo Random Number Generator to a random value
-#' 
+#'
 #' @details
 #' Depending on whether RcppArmadillo was compiled for the C++98 standard
 #' (currently the default) or for C++11 (optional), two different RNGs may be used.
@@ -26,29 +26,29 @@ armadillo_version <- function(single) {
 #' @return The function is invoked for its side effect and has no return value.
 #' @note This has been found to not work as espected in \pkg{RStudio}
 #' as its code also uses the system RNG library. You may have to either
-#' not run within \pkg{RStudio} or change your code to use a different RNG such 
+#' not run within \pkg{RStudio} or change your code to use a different RNG such
 #' as the one from R.
-#' @seealso The R documentation on its RNGs all of which are accessible via \pkg{Rcpp}.  
+#' @seealso The R documentation on its RNGs all of which are accessible via \pkg{Rcpp}.
 armadillo_set_seed_random <- function() {
     invisible(.Call(`_RcppArmadillo_armadillo_set_seed_random`))
 }
 
 #' Set the Armadillo Random Number Generator to the given value
-#' 
+#'
 #' @param val The seed used to initialize Armadillo's random number generator.
-#' @details 
+#' @details
 #' Depending on whether RcppArmadillo was compiled for the C++98 standard
 #' (currently the default) or for C++11 (optional), two different RNGs may be used.
 #' This function resets either. For C++98, the R programming language's RNG is used.
 #' For C++11, the RNG included in the \code{<random>} library is used only when
 #'  \code{#define ARMA_USE_CXX11_RNG} is placed before \code{#include <RcppArmadillo.h>}.
 #'  Otherwise, the R programming language's RNG will be used.
-#' @return The function is invoked for its side effect and has no return value. 
+#' @return The function is invoked for its side effect and has no return value.
 #' @note This has been found to not work as espected in \pkg{RStudio}
 #' as its code also uses the system RNG library. You may have to either
-#' not run within \pkg{RStudio} or change your code to use a different RNG such 
+#' not run within \pkg{RStudio} or change your code to use a different RNG such
 #' as the one from R.
-#' @seealso The R documentation on its RNGs all of which are accessible via \pkg{Rcpp}.  
+#' @seealso The R documentation on its RNGs all of which are accessible via \pkg{Rcpp}.
 armadillo_set_seed <- function(val) {
     invisible(.Call(`_RcppArmadillo_armadillo_set_seed`, val))
 }

--- a/inst/tinytest/test_sparseConversion.R
+++ b/inst/tinytest/test_sparseConversion.R
@@ -110,7 +110,7 @@ if (.onWindows) exit_file("Skipping remainder on Windows")
 ## [slam] p12 (dgCMatrix)
 x <- matrix(c(1, 0, 0, 2), nrow = 2)
 SM <- Matrix(x, sparse = TRUE)
-dgc <- as(SM, "dgCMatrix")
+dgc <- as(as(SM, "dgCMatrix"), "dgCMatrix") #the first coercion only outputs dtC Matrix
 expect_equal(dgc, asSpMat(SM))#, msg="dgC2dgC_9")
 
 ## [SparseM] p21 (dgCMatrix)


### PR DESCRIPTION
The coercion from ddi matrix to dgC matrix, e.g. `as(ddi_matrix, "dgCMatrix")`,  does not work as before, and its output is dtC matrix instead of dgC matrix.  So I have coerce again from dtC matrix to dgC matrix. 