### PR TITLE
Replace the checkException with equal_error function

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2020-12-31  Binxiang Ni  <binxiangni@gmail.com>
+
+	* inst/tinytest/test_sparseConversion.R: Replace the checkException with equal_error function; checkExpection function is not available in tinytest 
+
 2020-12-31  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): RcppArmadillo 0.10.1.2.1

--- a/inst/tinytest/test_sparseConversion.R
+++ b/inst/tinytest/test_sparseConversion.R
@@ -690,44 +690,40 @@ if (suppressMessages(require(slam))) {
     }
 }
 
-## this fails persistently at CRAN on the Fedora box, but shouldn't
-## giving up and commenting out
-## https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-clang/RcppArmadillo-00check.html
 ## test.stop <- function() {
-##     ## [Matrix] p87 (lgCMatrix)
-##     m <- Matrix(c(0,0,2:0), 3,5, dimnames=list(LETTERS[1:3],NULL))
-##     lm <- (m > 1)
-##     checkException(asSpMat(lm))
+## [Matrix] p87 (lgCMatrix)
+m <- Matrix(c(0,0,2:0), 3,5, dimnames=list(LETTERS[1:3],NULL))
+lm <- (m > 1)
+expect_error(asSpMat(lm))
 
-##     # [Matrix] p152 (lgTMatrix)
-##     L <- spMatrix(9, 30, i = rep(1:9, 3), 1:27,
-##                   (1:27) %% 4 != 1)
-##     checkException(asSpMat(L))
+## [Matrix] p152 (lgTMatrix)
+L <- spMatrix(9, 30, i = rep(1:9, 3), 1:27,
+              (1:27) %% 4 != 1)
+expect_error(asSpMat(L))
 
-##     ## [Matrix] p111 (ngCMatrix)
-##     m <- Matrix(c(0,0,2:0), 3,5, dimnames=list(LETTERS[1:3],NULL))
-##     dimnames(m) <- NULL
-##     nm <- as(m, "nsparseMatrix")
-##     checkException(asSpMat(nm))
+## [Matrix] p111 (ngCMatrix)
+m <- Matrix(c(0,0,2:0), 3,5, dimnames=list(LETTERS[1:3],NULL))
+dimnames(m) <- NULL
+nm <- as(m, "nsparseMatrix")
+expect_error(asSpMat(nm))
 
-##     ## [Matrix] p74 (ngTMatrix)
-##     sm1 <- as(rep(c(2,3,1), e=3), "indMatrix")
-##     ngt <- as(sm1, "ngTMatrix")
-##     checkException(asSpMat(ngt))
+## [Matrix] p74 (ngTMatrix)
+sm1 <- as(rep(c(2,3,1), e=3), "indMatrix")
+ngt <- as(sm1, "ngTMatrix")
+expect_error(asSpMat(ngt))
 
-##     ## [Matrix] p85 (ntTMatrix)
-##     lM <- Diagonal(x = c(TRUE,FALSE,FALSE))
-##     nM <- as(lM, "nMatrix")
-##     checkException(asSpMat(nM))
+## [Matrix] p85 (ntTMatrix)
+lM <- Diagonal(x = c(TRUE,FALSE,FALSE))
+nM <- as(lM, "nMatrix")
+expect_error(asSpMat(nM))
 
-##     ## [Matrix] p85 (nsCMatrix)
-##     nsc <- crossprod(nM)
-##     checkException(asSpMat(nsc))
+## [Matrix] p85 (nsCMatrix)
+nsc <- crossprod(nM)
+expect_error(asSpMat(nsc))
 
-##     ## [Matrix] p42 (ldiMatrix)
-##     ldi <- Diagonal(x = (1:4) >= 2)
-##     checkException(asSpMat(ldi))
-## }
+## [Matrix] p42 (ldiMatrix)
+ldi <- Diagonal(x = (1:4) >= 2)
+expect_error(asSpMat(ldi))
 
 ## test.as.lgc2dgc <- function() {
 ##     ## [Matrix] p87 (lgCMatrix) (To be continued)


### PR DESCRIPTION
If I don't remember wrong, we previously used `RUnit` package to conduct unit tests. But given we migrated to `tinytest` and `checkException` function is not available in the new package, the unit tests commented out failed. After replacing the functions with `equal_error` function from `tinytest` package, those unit tests work now. 

The [failure of tests](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-clang/RcppArmadillo-00check.html) should be due to the unit test we fixed yesterday, which lives in the line 114 of that unit test file.  