### PR TITLE
fix sign() to handle NaN

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2021-01-06  Conrad Sanderson  <conrad.sanderson.nospam@nogmail.com>
+
+        * inst/include/armadillo_bits/arma_cmath.hpp: fix handling of NaN by arma::sign()
+
 2021-01-01  Dirk Eddelbuettel  <edd@debian.org>
 
         * .github/workflows/ci.yaml: Add CI runner using r-ci

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2021-01-06  Conrad Sanderson  <conrad.sanderson.nospam@nogmail.com>
+2021-01-06  Conrad Sanderson  <cs.rcpparmadillo@gmail.com>
 
         * inst/include/armadillo_bits/arma_cmath.hpp: fix handling of NaN by arma::sign()
 

--- a/inst/include/armadillo_bits/arma_cmath.hpp
+++ b/inst/include/armadillo_bits/arma_cmath.hpp
@@ -183,7 +183,7 @@ constexpr
 typename arma_real_only<eT>::result
 arma_sign(const eT x)
   {
-  return (x > eT(0)) ? eT(+1) : ( (x < eT(0)) ? eT(-1) : eT(0) );
+  return (x > eT(0)) ? eT(+1) : ( (x < eT(0)) ? eT(-1) : ((x == eT(0)) ? eT(0) : x) );
   }
 
 


### PR DESCRIPTION
This commit fixes the sign() function to properly handle NaN values.  
When NaN is given, it now correctly returns NaN instead of incorrectly returning zero.  
Related bug report: https://gitlab.com/conradsnicta/armadillo-code/-/issues/169