### PR TITLE
error Rlog1p

### DIFF
--- a/inst/include/armadillo_bits/eop_aux.hpp
+++ b/inst/include/armadillo_bits/eop_aux.hpp
@@ -22,6 +22,8 @@
 //! use of the SFINAE approach to work around compiler limitations
 //! http://en.wikipedia.org/wiki/SFINAE
 
+#undef log1p
+
 class eop_aux
   {
   public:


### PR DESCRIPTION
On

```
R version 4.0.3 (2020-10-10)
Platform: aarch64-apple-darwin20.0.0 (64-bit)
Apple clang version 12.0.0 (clang-1200.0.32.29)
Target: arm64-apple-darwin20.3.0
```

The original source code fails with the message:

```
../inst/include/armadillo_bits/eop_aux.hpp:98:115: error: no member named 'Rlog1p' in namespace 'std'; did you mean simply 'Rlog1p'?
```

which shows a conflict of `std::log1p` with `#define log1p Rlog1p` in `Rmath.h`