### PR TITLE
handle subview_cols in Armadillo 10.7

### DIFF
--- a/inst/include/RcppArmadilloForward.h
+++ b/inst/include/RcppArmadilloForward.h
@@ -4,6 +4,7 @@
 // RcppArmadilloForward.h: Rcpp/Armadillo glue
 //
 // Copyright (C)  2010 - 2014  Dirk Eddelbuettel, Romain Francois and Douglas Bates
+// Copyright (C)  2021  Conrad Sanderson
 //
 // This file is part of RcppArmadillo.
 //
@@ -57,6 +58,7 @@ namespace Rcpp {
     template <typename T> SEXP wrap ( const arma::field<T>& ) ;
     template <typename T> SEXP wrap ( const arma::Cube<T>& ) ;
     template <typename T> SEXP wrap ( const arma::subview<T>& ) ;
+    template <typename T> SEXP wrap ( const arma::subview_cols<T>& ) ;
     template <typename T> SEXP wrap ( const arma::SpMat<T>& ) ;
     
     template <typename T1, typename T2, typename glue_type> 

--- a/inst/include/RcppArmadilloWrap.h
+++ b/inst/include/RcppArmadilloWrap.h
@@ -4,7 +4,7 @@
 // RcppArmadilloWrap.h: Rcpp/Armadillo glue
 //
 // Copyright (C)  2010 - 2013  Dirk Eddelbuettel, Romain Francois and Douglas Bates
-// Copyright (C)  2021 Conrad Sanderson
+// Copyright (C)  2021  Conrad Sanderson
 //
 // This file is part of RcppArmadillo.
 //

--- a/inst/include/RcppArmadilloWrap.h
+++ b/inst/include/RcppArmadilloWrap.h
@@ -4,6 +4,7 @@
 // RcppArmadilloWrap.h: Rcpp/Armadillo glue
 //
 // Copyright (C)  2010 - 2013  Dirk Eddelbuettel, Romain Francois and Douglas Bates
+// Copyright (C)  2021 Conrad Sanderson
 //
 // This file is part of RcppArmadillo.
 //
@@ -53,6 +54,17 @@ namespace Rcpp{
             return mat ;
 	}
 	
+	template <typename T>
+	SEXP arma_subview_wrap( const arma::subview_cols<T>& data, int nrows, int ncols ){
+            const int RTYPE = Rcpp::traits::r_sexptype_traits<T>::rtype ;
+            Rcpp::Matrix<RTYPE> mat( nrows, ncols ) ;
+            const int nelem = nrows*ncols;
+            const T* svcmem = data.colptr(0);
+            for( int i=0; i<nelem; i++)
+                mat[i] = svcmem[i] ;
+            return mat ;
+	}
+
     } /* namespace RcppArmadillo */
 	
     /* wrap */
@@ -84,6 +96,11 @@ namespace Rcpp{
     template <typename T> SEXP wrap( const arma::subview<T>& data ){
         return RcppArmadillo::arma_subview_wrap<T>( data, data.n_rows, data.n_cols ) ;
     }
+
+    template <typename T> SEXP wrap( const arma::subview_cols<T>& data ){
+        return RcppArmadillo::arma_subview_wrap<T>( data, data.n_rows, data.n_cols ) ;
+    }
+
     
     template <typename T> SEXP wrap ( const arma::SpMat<T>& sm ){
         const int  RTYPE = Rcpp::traits::r_sexptype_traits<T>::rtype;

--- a/inst/include/RcppArmadilloWrap.h
+++ b/inst/include/RcppArmadilloWrap.h
@@ -50,7 +50,7 @@ namespace Rcpp{
             Rcpp::Matrix<RTYPE> mat( nrows, ncols ) ;
             for( int j=0, k=0; j<ncols; j++)
                 for( int i=0; i<nrows; i++, k++) 
-                    mat[k] = data(i,j) ;
+                    mat[k] = data.at(i,j) ;   // use .at() to skip unnecessary bounds checks
             return mat ;
 	}
 	


### PR DESCRIPTION
- add handling of subview_cols<T>
- speedup in handling subview<T>: since the size is known, use .at() to skip unnecessary bounds checks