### PR TITLE
simplification

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Rcpp::List fastLm(const arma::mat& X, const arma::colvec& y) {
     arma::colvec res  = y - X*coef;           // residuals
 
     // std.errors of coefficients
-    double s2 = std::inner_product(res.begin(), res.end(), res.begin(), 0.0)/(n - k);
+    double s2 = arma::dot(res,res) / (n - k);
 
     arma::colvec std_err = arma::sqrt(s2 * arma::diagvec(arma::pinv(arma::trans(X)*X)));
 

--- a/src/fastLm.cpp
+++ b/src/fastLm.cpp
@@ -30,7 +30,7 @@ List fastLm_impl(const arma::mat& X, const arma::colvec& y) {
     arma::colvec res  = y - X*coef;           // residuals
 
     // std.errors of coefficients
-    double s2 = std::inner_product(res.begin(), res.end(), res.begin(), 0.0)/(n - k);
+    double s2 = arma::dot(res, res) / (n - k);
                                                         
     arma::colvec std_err = arma::sqrt(s2 * arma::diagvec(arma::pinv(arma::trans(X)*X)));  
 


### PR DESCRIPTION
arma::dot() is simpler and more intuitive to use than std::inner_product().  

arma::dot() is also faster than std::inner_product(). Armadillo maps arma::dot() to BLAS ddot(), which is accelerated by OpenBLAS (or MKL).