### PR TITLE
set includes in PKG_CPPFLAGS

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-02-11  Kevin Ushey  <kevinushey@gmail.com>
+
+	* src/Makevars.in: Use PKG_CPPFLAGS for RcppArmadillo includes
+
 2023-02-09  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): RcppArmadillo 0.11.4.4.0

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,6 +1,7 @@
 ## -*- mode: makefile; -*-
 
-PKG_CXXFLAGS = -I../inst/include @OPENMP_FLAG@
+PKG_CPPFLAGS = -I../inst/include
+PKG_CXXFLAGS = @OPENMP_FLAG@
 PKG_LIBS= @OPENMP_FLAG@ $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
 
 ## With R 3.1.0 or later, you can uncomment the following line to tell R to


### PR DESCRIPTION
Fixes the underlying issue in https://github.com/RcppCore/RcppArmadillo/issues/406. With this, the compiler invocation when building on macOS is (for example):

```
clang++ -mmacosx-version-min=10.13 -std=gnu++14 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include -I'/Users/kevin/Library/R/x86_64/4.2/library/Rcpp/include' -I/usr/local/include   -fPIC  -Wall -g -O2  -c RcppArmadillo.cpp -o RcppArmadillo.o
< ... >
```

And because `-I../inst/include` is now coming before `-I/usr/local/include`, we should now be able to avoid issues where a system installation of Armadillo in `/usr/local/include` takes precedence over the bundled version.