### PR TITLE
Remove file non-user facing leagcy header files (closes #400)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2024-01-18  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/RcppArmadilloAs.h: Remove non-user facing include
+	file, the prefered alternative in RcppArmadillo/ is available
+	* inst/include/RcppArmadilloConfig.h: Idem
+	* inst/include/RcppArmadilloForward.h: Idem
+	* inst/include/RcppArmadilloSugar.h: Idem
+	* inst/include/RcppArmadilloWrap.h: Idem
+
 2023-12-18  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): RcppArmadillo 0.12.6.7.0

--- a/inst/include/RcppArmadilloAs.h
+++ b/inst/include/RcppArmadilloAs.h
@@ -1,5 +1,0 @@
-
-
-// This file support the legacy location and includes from the new location
-
-#include "RcppArmadillo/interface/RcppArmadilloAs.h"

--- a/inst/include/RcppArmadilloConfig.h
+++ b/inst/include/RcppArmadilloConfig.h
@@ -1,5 +1,0 @@
-
-
-// This file support the legacy location and includes from the new location
-
-#include "RcppArmadillo/config/RcppArmadilloConfig.h"

--- a/inst/include/RcppArmadilloForward.h
+++ b/inst/include/RcppArmadilloForward.h
@@ -1,5 +1,0 @@
-
-
-// This file support the legacy location and includes from the new location
-
-#include "RcppArmadillo/interface/RcppArmadilloForward.h"

--- a/inst/include/RcppArmadilloSugar.h
+++ b/inst/include/RcppArmadilloSugar.h
@@ -1,5 +1,0 @@
-
-
-// This file support the legacy location and includes from the new location
-
-#include "RcppArmadillo/interface/RcppArmadilloSugar.h"

--- a/inst/include/RcppArmadilloWrap.h
+++ b/inst/include/RcppArmadilloWrap.h
@@ -1,5 +1,0 @@
-
-
-// This file support the legacy location and includes from the new location
-
-#include "RcppArmadillo/interface/RcppArmadilloWrap.h"


### PR DESCRIPTION
This finished what #395 and #396 started.

A full set of reverse-dependency checks asserted that this does not affect any CRAN packages.