### PR TITLE
Disable scipy error test

### DIFF
--- a/inst/tinytest/test_scipy2r.R
+++ b/inst/tinytest/test_scipy2r.R
@@ -75,4 +75,4 @@ expect_equal(dgR, csr, info="csr2dgr") #RcppArmadillo:::.SciPy2R(csr))
 #test.other <- function() {
 #bsr <- sp$bsr_matrix(list(3, 4))
 #expect_error(RcppArmadillo:::.SciPy2R(bsr))
-expect_error(sp$bsr_matrix(list(3, 4)))
+#expect_error(sp$bsr_matrix(list(3, 4)))


### PR DESCRIPTION
This removes a failing test which CRAN reported as failing with reticulate release 1.36.
The failing test is:
```r
expect_error(sp$bsr_matrix(list(3, 4)))
```

Looking a little closer, it looks like this was never supposed to error. 
For example, the equivalent code succeeds in Python, and it should've in R as well.
```python
import scipy.sparse as sp
x = sp.bsr_matrix([3, 4])
print(repr(x))
```
```
<1x2 sparse matrix of type '<class 'numpy.longlong'>'
	with 2 stored elements (blocksize = 1x1) in Block Sparse Row format>
```
This code both with the current release of scipy, v1.13.0, and as well as v1.3.3, the released Nov 2019.

This did indeed error with reticulate 1.35 and older versions, but the error was unrelated, and incorrect. Specifically, it would signal an R error with traceback:

```
<error/rlang_error>
Error in `py_to_r.default()`:
! Object to convert is not a Python object
---
Backtrace:
    ▆
 1. └─sp$bsr_matrix(list(3, 4))
 2.   ├─reticulate::py_to_r(result)
 3.   └─reticulate:::py_to_r.scipy.sparse.base.spmatrix(result)
 4.     ├─reticulate::py_to_r(x$tocsc())
 5.     └─reticulate:::py_to_r.default(x$tocsc())
```

 I.e., the call to `sp$bsr_matrix()` would succeed, but then `py_to_r(x$tocsc())` would convert to an R object automatically which did not need additional `py_to_r()` processing. With reticulate 1.36, `reticulate::py_to_r()` now reflects non-Python objects instead of signaling an error.