### PR TITLE
Swap order of the two bibentry instances

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,6 +1,3 @@
-bibentry("Manual",
-         other = unlist(citation(auto = meta), recursive = FALSE))
-
 bibentry("Article",
          title = "RcppArmadillo: Accelerating R with high-performance C++ linear algebra",
          author = c(person("Dirk", "Eddelbuettel",
@@ -15,3 +12,6 @@ bibentry("Article",
          pages = "1054--1063",
          doi = "10.1016/j.csda.2013.02.005"
          )
+
+bibentry("Manual",
+         other = unlist(citation(auto = meta), recursive = FALSE))


### PR DESCRIPTION
@eddelbuettel  The peer-reviewed article should be cited before the manual.  Detailed reasoning given in email.
