### PR TITLE
Provides armadillo header for direct include

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2025-09-02  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/armadillo: Moved back up from legacy/ to restore path
+	* inst/include/armadillo_bits/: Idem
+
+
 2025-09-01  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): RcppArmadillo 15.0.1-1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: RcppArmadillo
 Type: Package
 Title: 'Rcpp' Integration for the 'Armadillo' Templated Linear Algebra Library
-Version: 15.0.1-1
-Date: 2025-09-01
+Version: 15.0.1-2
+Date: 2025-09-02
 Authors@R: c(person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd@debian.org",
                     comment = c(ORCID = "0000-0001-6419-907X")),
              person("Romain", "Francois", role = "aut",

--- a/inst/include/armadillo
+++ b/inst/include/armadillo
@@ -1,0 +1,37 @@
+
+// Replacement header providing the original path so that '#include <armadillo>' works
+// with the R package -- but it is recommended to include only the RcppArmadillo header
+
+
+#ifndef RcppArmadillo__armadillo__h
+#define RcppArmadillo__armadillo__h
+
+// See version/arma.h header for the (user and/or compilation) drive selection of these defines
+#if defined(ARMA_SELECTED_CURRENT_VERSION)
+
+    // we include Armadillo 15.0.1 here -- but do it quietly
+    //#pragma message("Using compilation with current Armadillo version.")
+
+    // Armadillo 15.0.1 or later
+    #include "current/armadillo"
+
+#else
+
+    // we include Armadillo 14.6.3 here -- but do it quietly
+    //#pragma message("Using fallback compilation with Armadillo 14.6.3.")
+
+    // Armadillo has deprecation warnings (which RcppArmadillo suppressed at time to
+    // minimise issies at CRAN).  Should your package display any, and you decide
+    // _not_ to fix the root causes (see RcppArmadillo GitHub Issues #391 and #402
+    // for details) then defining the following macro will help. You can add a
+    // #define in your source code before including the RcppArmadillo header, or add
+    // a -DARMA_IGNORE_DEPRECATED_MARKER to the PKG_CPPFLAGS in src/Makevars.
+    //
+    // Renabling globally again for Armadillo 14.6.* as too many packages trigger this
+    #define ARMA_IGNORE_DEPRECATED_MARKER
+
+    #include "legacy/armadillo"
+
+#endif
+
+#endif


### PR DESCRIPTION
When injecting the fallback Armadillo 14.6.3 as 'legacy' along with the current 15.0.1 as 'current', we removed the access point 'armadillo' so a line such as `#inc;lude <armadillo>` no longer worked.   While packages are generally to use `#include <RcppArmadillo.h>` (or one of the newer forms such as `#include <RcppArmadillo/Ligher>`) the old form needs to be supported and this PR does that.