### PR TITLE
No longer infer insufficient LAPACK from libRlapack use

### DIFF
--- a/configure
+++ b/configure
@@ -612,7 +612,6 @@ ac_subst_vars='LTLIBOBJS
 LIBOBJS
 OPENMP_FLAG
 ARMA_HAVE_OPENMP
-ARMA_LAPACK
 CXXCPP
 OBJEXT
 EXEEXT
@@ -3394,14 +3393,13 @@ if test x"${hasRlapack}" = x""; then
     ## We are using a full Lapack and can use zgbsv -- so #undef remains
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: system LAPACK found" >&5
 printf "%s\n" "system LAPACK found" >&6; }
-    arma_lapack="#undef ARMA_CRIPPLED_LAPACK"
+    ## arma_lapack="#undef ARMA_CRIPPLED_LAPACK"
 else
     ## We are using R's subset of Lapack and CANNOT use zgbsv etc, so we mark it
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: R-supplied partial LAPACK found" >&5
 printf "%s\n" "R-supplied partial LAPACK found" >&6; }
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Some complex-valued LAPACK functions may not be available" >&5
-printf "%s\n" "$as_me: WARNING: Some complex-valued LAPACK functions may not be available" >&2;}
-    arma_lapack="#define ARMA_CRIPPLED_LAPACK 1"
+    ## AC_MSG_WARN([Some complex-valued LAPACK functions may not be available])
+    ## arma_lapack="#define ARMA_CRIPPLED_LAPACK 1"
 fi
 
 ## Default the OpenMP flag to the empty string.
@@ -3436,8 +3434,7 @@ fi
 
 
 ## now use all these
-ARMA_LAPACK="${arma_lapack}"
-
+## AC_SUBST([ARMA_LAPACK],["${arma_lapack}"])
 ARMA_HAVE_OPENMP="${arma_have_openmp}"
 
 OPENMP_FLAG="${openmp_flag}"

--- a/configure.ac
+++ b/configure.ac
@@ -167,12 +167,12 @@ hasRlapack=$(echo ${lapack} | grep lRlapack)
 if test x"${hasRlapack}" = x""; then
     ## We are using a full Lapack and can use zgbsv -- so #undef remains
     AC_MSG_RESULT([system LAPACK found])
-    arma_lapack="#undef ARMA_CRIPPLED_LAPACK"
+    ## arma_lapack="#undef ARMA_CRIPPLED_LAPACK"
 else
     ## We are using R's subset of Lapack and CANNOT use zgbsv etc, so we mark it
     AC_MSG_RESULT([R-supplied partial LAPACK found])
-    AC_MSG_WARN([Some complex-valued LAPACK functions may not be available])
-    arma_lapack="#define ARMA_CRIPPLED_LAPACK 1"
+    ## AC_MSG_WARN([Some complex-valued LAPACK functions may not be available])
+    ## arma_lapack="#define ARMA_CRIPPLED_LAPACK 1"
 fi
 
 ## Default the OpenMP flag to the empty string.
@@ -204,7 +204,7 @@ fi
 
 
 ## now use all these
-AC_SUBST([ARMA_LAPACK],["${arma_lapack}"])
+## AC_SUBST([ARMA_LAPACK],["${arma_lapack}"])
 AC_SUBST([ARMA_HAVE_OPENMP], ["${arma_have_openmp}"])
 AC_SUBST([OPENMP_FLAG], ["${openmp_flag}"])
 AC_CONFIG_FILES([inst/include/RcppArmadillo/config/RcppArmadilloConfigGenerated.h src/Makevars])

--- a/inst/include/RcppArmadillo/config/RcppArmadilloConfigGenerated.h.in
+++ b/inst/include/RcppArmadillo/config/RcppArmadilloConfigGenerated.h.in
@@ -21,11 +21,6 @@
 #ifndef RcppArmadillo__RcppArmadilloConfigGenerated__h
 #define RcppArmadillo__RcppArmadilloConfigGenerated__h
 
-#ifndef ARMA_CRIPPLED_LAPACK
-// value on next line may be changed between #undef and #define by the configure script
-@ARMA_LAPACK@
-#endif
-
 #ifndef ARMA_USE_OPENMP
 // from configure test for OpenMP based on how R is configured, and whether g++ new enough
 @ARMA_HAVE_OPENMP@


### PR DESCRIPTION
Closes #481 

We no longer pass down whether R uses its internal `libRlapack` library.  This library uses to be insufficient, hence the need for a flag but should now be complete for our purposes, including for complex variables.